### PR TITLE
Adds progress bar to downloads

### DIFF
--- a/python/sdss_access/sync/cli.py
+++ b/python/sdss_access/sync/cli.py
@@ -92,9 +92,10 @@ class Cli(object):
                 running_files = n_tasks - finished_files
 
                 if self.verbose:
-                    print("SDSS_ACCESS> syncing... please wait for {0} rsync streams ({1} files) to"
-                          " complete [running for {2} seconds]".format(running_count, running_files,
-                                                                       pause_count * pause))
+                    tqdm.write("SDSS_ACCESS> syncing... please wait for {0} rsync streams ({1} "
+                               "files) to complete [running for {2} seconds]".format(running_count,
+                                                                                     running_files,
+                                                                                     pause_count * pause))
 
                 # update the process polling
                 sleep(pause)

--- a/python/sdss_access/sync/http.py
+++ b/python/sdss_access/sync/http.py
@@ -13,6 +13,7 @@ from os import makedirs
 from os.path import isfile, exists, dirname
 from sdss_access import SDSSPath
 from sdss_access.sync.auth import Auth, AuthMixin
+from tqdm import tqdm
 
 
 class HttpAccess(AuthMixin, SDSSPath):
@@ -121,12 +122,15 @@ class HttpAccess(AuthMixin, SDSSPath):
 
                     file_size_dl = 0
                     block_sz = 8192
-                    while True:
-                        buffer = u.read(block_sz)
-                        if not buffer:
-                            break
-                        file_size_dl += len(buffer)
-                        file.write(buffer)
+                    # set up progress bar
+                    with tqdm(total=file_size, unit='B', unit_scale=True, unit_divisor=1024, desc='Progress') as pbar:
+                        while True:
+                            buffer = u.read(block_sz)
+                            if not buffer:
+                                break
+                            file_size_dl += len(buffer)
+                            pbar.update(len(buffer))
+                            file.write(buffer)
 
                 if self.verbose:
                     if path_exists:

--- a/python/sdss_access/sync/stream.py
+++ b/python/sdss_access/sync/stream.py
@@ -122,7 +122,7 @@ class Stream(object):
             streamlet['path'] = self.cli.get_path(index=streamlet['index'])
             path_txt = "{0}.txt".format(streamlet['path'])
             streamlet['command'] = self.command.format(path=path_txt, source=self.source, destination=self.destination)
-    
+
             if 'rsync -' in self.command:
                 self.cli.write_lines(path=path_txt, lines=[location for location in streamlet['location']])
             else:
@@ -139,7 +139,7 @@ class Stream(object):
             if self.verbose:
                 print("SDSS_ACCESS> rsync stream %s logging to %s" % (streamlet['index'],streamlet['logfile'].name))
 
-        self.cli.wait_for_processes(list(streamlet['process'] for streamlet in self.streamlet))
+        self.cli.wait_for_processes(list(streamlet['process'] for streamlet in self.streamlet), n_tasks=len(self.task))
 
         if any(self.cli.returncode):
             path = self.streamlet[0]['path'][:-3]

--- a/python/sdss_access/sync/stream.py
+++ b/python/sdss_access/sync/stream.py
@@ -44,9 +44,11 @@ class Stream(object):
             try:
                 n = len(location)
                 ok = n == len(source) and n == len(destination)
-                streamlet['location'], streamlet['source'], streamlet['destination'] = (location, source, destination) if ok else (None, None, None)
+                streamlet['location'], streamlet['source'], streamlet['destination'] = (
+                    location, source, destination) if ok else (None, None, None)
             except Exception:
-                streamlet['location'], streamlet['source'], streamlet['destination'] = (None, None, None)
+                streamlet['location'], streamlet['source'], streamlet['destination'] = (
+                    None, None, None)
 
     def get_streamlet(self, index=None, increment=1):
         if index is None:
@@ -139,7 +141,11 @@ class Stream(object):
             if self.verbose:
                 print("SDSS_ACCESS> rsync stream %s logging to %s" % (streamlet['index'],streamlet['logfile'].name))
 
-        self.cli.wait_for_processes(list(streamlet['process'] for streamlet in self.streamlet), n_tasks=len(self.task))
+        # get the number of tasks per stream
+        tasks_per_stream = [len(streamlet['location']) for streamlet in self.streamlet]
+        # submit the stream subprocesses to the background
+        self.cli.wait_for_processes(list(streamlet['process'] for streamlet in self.streamlet),
+                                    n_tasks=len(self.task), tasks_per_stream=tasks_per_stream)
 
         if any(self.cli.returncode):
             path = self.streamlet[0]['path'][:-3]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     requests>=2.10.0
     sdss-tree>=3.0.0
 	sdsstools>=0.1.7
+	tqdm>=4.46.0
 
 scripts =
 

--- a/tests/sync/test_http.py
+++ b/tests/sync/test_http.py
@@ -58,6 +58,13 @@ class TestHttp(object):
 
         assert os.path.exists(full)
 
+    def test_http_public_dl(self, monkeyprod):
+        http = HttpAccess(release='DR14')
+        http.remote()
+        full = http.full('spec-lite', run2d='v5_10_0', plateid=3606, mjd=55182, fiberid=537)
+        http.get('spec-lite', run2d='v5_10_0', plateid=3606, mjd=55182, fiberid=537)
+        assert os.path.exists(full)
+
     def test_nonetrc_fails(self, monkeyhome):
         ''' test raise error when no netrc present '''
         with pytest.raises(AccessError) as cm:


### PR DESCRIPTION
This PR addresses #7 and adds a `tqdm` ([tqdm](https://github.com/tqdm/tqdm)) progress bar to rsync and http downloads.  Adds `tqdm>=4.46.0` as a requirement to `sdss_access`.   When used with `http.get`, progress bar displays the progress of the file size download.  When used with `rsync.commit` displays the progress of the number of files processed within the streams.  

STILL TODO
- [ ] test on Windows with curl     