### PR TITLE
Path now accepts a loaded module as a version

### DIFF
--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -63,7 +63,7 @@ class BasePath(object):
                "mirror": "data.mirror.sdss.org", 'svn': 'svn.sdss.org'}
 
     def __init__(self, release=None, public=False, mirror=False, verbose=False, force_modules=None):
-        self.release = release or 'sdsswork'
+        self.release = release or os.getenv('TREE_VER', 'sdsswork')
         self.public = 'dr' in self.release.lower() or public
         self.mirror = mirror
         self.verbose = verbose

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,7 @@ def radd(rsync, expdata):
     ''' fixture to add a path to an rsync object '''
     rsync.add(expdata['name'], **expdata['params'])
     yield rsync
+    rsync.reset()
 
 
 @pytest.fixture(scope='session')
@@ -141,6 +142,7 @@ def rstream(radd):
     ''' fixture to set the stream for an parametrized rsync object '''
     radd.set_stream()
     yield radd
+    radd.reset()
 
 
 @pytest.fixture(scope='session')

--- a/tests/data/paths.yaml
+++ b/tests/data/paths.yaml
@@ -8,4 +8,7 @@ paths:
     work: mangawork
     params: {drpver: v2_4_3, plate: 8485, ifu: 1901, wave: LOG}
     location: manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGCUBE.fits.gz
-
+  - name: spec-lite
+    work: ebosswork
+    params: {run2d: v5_10_0, plateid: 3606, mjd: 55182, fiberid: 537}
+    location: eboss/spectro/redux/v5_10_0/spectra/lite/3606/spec-3606-55182-0537.fits

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -247,6 +247,24 @@ class TestPath(object):
         ff = path.full('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007', force_module=True)
         assert 'mangapreim/trunk/data' in ff
 
+    @pytest.mark.parametrize('tree_ver', [('sdsswork'), ('dr15'), ('sdss5'), ('mpl8')])
+    def test_release_from_module(self, monkeypatch, tree_ver):
+        monkeypatch.setenv('TREE_VER', tree_ver)
+        path = Path()
+        assert path.release == tree_ver
+
+    def test_sdss5_paths(self, monkeypatch):
+        path = Path(release='sdss5')
+        assert 'rsFields' in path.templates
+        f1 = path.full('rsFields', plan='001', observatory='APO')
+
+        monkeypatch.setenv('TREE_VER', 'sdss5')
+        path = Path()
+        assert 'rsFields' in path.templates
+        f2 = path.full('rsFields', plan='001', observatory='APO')
+
+        assert f1 == f2
+
 
 @pytest.fixture()
 def monkeyoos(monkeypatch):

--- a/tests/sync/test_http.py
+++ b/tests/sync/test_http.py
@@ -72,3 +72,13 @@ class TestHttp(object):
         assert http.public is True
         assert http.auth.username is None
         assert http.auth.ready() is None
+
+    @pytest.mark.parametrize('tree_ver, exp', [('sdsswork', 'work'), ('dr15', 'dr15'),
+                                               ('dr13', 'dr13'), ('mpl8', 'work')])
+    def test_release_from_module(self, monkeypatch, tree_ver, exp, datapath):
+        monkeypatch.setenv('TREE_VER', tree_ver)
+        http = HttpAccess()
+        full = http.full(datapath['name'], **datapath['params'])
+        assert http.release == tree_ver
+        assert exp in full
+

--- a/tests/sync/test_rsync.py
+++ b/tests/sync/test_rsync.py
@@ -12,6 +12,7 @@ from __future__ import print_function, division, absolute_import
 import os
 import pytest
 from sdss_access import Access, AccessError
+from sdss_access.sync import RsyncAccess
 
 
 class TestRsync(object):
@@ -43,6 +44,17 @@ class TestRsync(object):
         print('path', path)
         assert os.path.exists(path) is True
         assert os.path.isfile(path) is True
+
+    @pytest.mark.parametrize('tree_ver, exp', [('sdsswork', 'work'), ('dr15', 'dr15'),
+                                               ('dr13', 'dr13'), ('mpl8', 'work')])
+    def test_release_from_module(self, monkeypatch, tree_ver, exp, datapath):
+        monkeypatch.setenv('TREE_VER', tree_ver)
+        rsync = RsyncAccess()
+        rsync.remote()
+        rsync.add(datapath['name'], **datapath['params'])
+        loc = rsync.initial_stream.task[0]['location']
+        assert rsync.release == tree_ver
+        assert exp in loc
 
 
 class TestRsyncFails(object):


### PR DESCRIPTION
This PR fixes #18.  Path can now be instantiated off a loaded module.  The order of precedence is an input `release` -> `TREE_VER` -> "sdsswork" as a valid release.   The following loads sdss5 paths
```
module load tree/sdss5
path = Path()
path.full('rsFields', plan='001', observatory='APO')
'/Users/Brian/Work/sdss/sas/sdss5/sandbox/robostrategy/allocations/001/rsFields-001-APO.fits'
```
or to load DR paths
```
module load tree/dr14
path = Path()
path.full('spec-lite', run2d='v5_10_0', plateid=3606, mjd=55182, fiberid=537)
'/Users/Brian/Work/sdss/sas/dr14/eboss/spectro/redux/v5_10_0/spectra/lite/3606/spec-3606-55182-0537.fits'
```
 This works if `TREE_VER` is only set within the created environment module files.  You can still dynamically override by calling Path with a release i.e. `Path(release="DR16")`.  I've also added tests to check that locations are correct for `HttpAccess` and `RsyncAccess` and items download in the correct places.    
