### PR TITLE
Adds tests for configgrp, prep for new tag

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.1dev
+current_version = 2.0.1
 commit = True
 tag = False
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.1
+current_version = 2.0.2dev
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,12 +6,16 @@ Change Log
 
 This document records the main changes to the sdss_access code.
 
+2.0.1 (2022-05-13)
+------------------
+- Adds new `configgrp` special function.
+
 2.0.0 (2021-09-24)
 ------------------
 - Breaking Change: switches `sdss_access` to use new SDSS dtn.sdss.org server
 - Feature: adds new "data.sdss5.org" server to support rsync, curl, and http downloads for sdss5 products
 - Adding new Sphinx docs for SDSS collaboration authentication
-- Updates the public release check to now check todays date against the tree release date, and "DR" in release name. 
+- Updates the public release check to now check todays date against the tree release date, and "DR" in release name.
 
 1.1.1 (2020-11-11)
 ------------------

--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -39,12 +39,12 @@ Depends on the tree product. In particular requires path templates in:
 
 
 def check_public_release(release: str = None, public: bool = False) -> bool:
-    """ Check if a release is public 
-    
+    """ Check if a release is public
+
     Checks a given release to see if it is public.  A release is public if it
     contains "DR" in the release name, and if todays date is <= the release_date
-    as specified in the Tree. 
-    
+    as specified in the Tree.
+
     Parameters
     ----------
     release : str
@@ -56,7 +56,7 @@ def check_public_release(release: str = None, public: bool = False) -> bool:
     -------
     bool
         If the release if public
-        
+
     Raises
     ------
     AttributeError
@@ -64,7 +64,7 @@ def check_public_release(release: str = None, public: bool = False) -> bool:
     """
     today = datetime.datetime.now().date()
     release_date = getattr(tree, 'release_date', None)
-    
+
     # check if tree has a valid release date attr
     if release_date is None and "DR" in tree.release:
         raise AttributeError("Cannot find a valid release date in the sdss-tree product.  Try upgrading to min. version 3.1.0.")
@@ -118,11 +118,11 @@ class BasePath(object):
         self.templates = tree.paths
         if self.release:
             self.replant_tree(release=self.release)
-            
+
         # set public and mirror keywords
         self.public = check_public_release(release=self.release, public=public)
         self.mirror = mirror
-            
+
         # set the server location and remote base
         self.set_netloc()
         self.set_remote_base()
@@ -327,7 +327,7 @@ class BasePath(object):
         elif re.search('@healpixgrp[|]', template):
             template = re.sub('@healpixgrp[|]', '{healpixgrp}', template)
         elif re.search('@configgrp[|]', template):
-            template = re.sub('@configgrp[|]', '{configgrp}', template)             
+            template = re.sub('@configgrp[|]', '{configgrp}', template)
         if re.search('@plateid6[|]', template):
             template = re.sub('@plateid6[|]', '{plateid:0>6}', template)
 
@@ -444,8 +444,9 @@ class BasePath(object):
         if remote:
             # check for remote existence using a HEAD request
             url = self.url('', full=full)
+            verify = kwargs.get('verify', True)
             try:
-                resp = requests.head(url, allow_redirects=True)
+                resp = requests.head(url, allow_redirects=True, verify=verify)
             except Exception as e:
                 raise AccessError('Cannot check for remote file existence for {0}: {1}'.format(url, e))
             else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-access
-version = 2.0.1
+version = 2.0.2dev
 author = Brian Cherinka
 author_email = bcherinka@stsci.edu
 description = Package to dynamically build filepaths and access all SDSS SAS products
@@ -60,7 +60,7 @@ dev =
 	pytest-mock>=1.13.0
 	pytest-sugar>=0.9.2
 	isort>=4.3.21
-	codecov>=2.0.15
+	codecov>=2.0.2dev5
 	coverage[toml]>=5.0
     coveralls>=1.7
 	ipdb>=0.12.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-access
-version = 2.0.1dev
+version = 2.0.1
 author = Brian Cherinka
 author_email = bcherinka@stsci.edu
 description = Package to dynamically build filepaths and access all SDSS SAS products

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ docs =
 	recommonmark>=0.6
 	sphinx-issues>=1.2.0
 	importlib_metadata>=1.6.0
-	Jinja2<=3.1
+	Jinja2<=3.0
 
 [isort]
 line_length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,7 @@ docs =
 	recommonmark>=0.6
 	sphinx-issues>=1.2.0
 	importlib_metadata>=1.6.0
+	Jinja2<=3.1
 
 [isort]
 line_length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ package_dir =
 install_requires =
     six>=1.11
     requests>=2.10.0
-    sdss-tree>=3.0.0
+    sdss-tree>=3.1.2
 	sdsstools>=0.4.5
 	tqdm>=4.46.0
 

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -39,7 +39,7 @@ class TestPath(object):
     @pytest.mark.parametrize('place, exp', [('local', False), ('remote', True)])
     def test_existence(self, path, place, exp):
         full = path.full('mangaimage', drpver='v2_5_3', plate=8116, ifu=1901, dir3d='mastar')
-        exists = path.exists('', full=full, remote=(place == 'remote'))
+        exists = path.exists('', full=full, remote=(place == 'remote'), verify=False)
         assert exp == exists
 
     def test_lookup_names(self, path):
@@ -297,7 +297,7 @@ class TestPath(object):
         path = Path(release='DR15')
         ff = path.full('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007')
         assert 'mangapreim/v2_5/data' in ff
-        
+
         ff = path.full('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007', force_module=True)
         assert 'mangapreim/trunk/data' in ff
 

--- a/tests/path/test_sdss5.py
+++ b/tests/path/test_sdss5.py
@@ -28,16 +28,31 @@ def path():
 class TestSVPaths(object):
 
     @pytest.mark.parametrize('name, special, keys, exp',
-                             [('apStar', '@apgprefix',
+                             [('apStar', '@healpixgrp',
                                {'apred': 'r12', 'apstar': 'stars', 'telescope': 'apo25m',
                                 'healpix': '12345', 'obj': '12345'},
-                               'r12/stars/apo25m/12/12345/apStar-r12-12345.fits')],
+                               'r12/stars/apo25m/12/12345/apStar-r12-apo25m-12345.fits')],
                              ids=['apStar'])
     def test_apogee_paths(self, path, name, special, keys, exp):
         assert special in path.templates[name]
         full = path.full(name, **keys)
         assert exp in full
-        
+
+    @pytest.mark.parametrize('name, special, keys, exp',
+                             [('confSummary', '@configgrp', {'configid': 1234, 'obs': 'apo'},
+                               '0012XX/confSummary-1234.par'),
+                              ('apField', '@apgprefix', {'telescope': 'apo25m', 'apred': 'r12', 'field': '2J01'},
+                               'redux/r12/stars/apo25m/2J01/apField-2J01.fits'),
+                              ('apField', '@apgprefix', {'telescope': 'lco25m', 'apred': 'r12', 'field': '2J01'},
+                               'redux/r12/stars/lco25m/2J01/asField-2J01.fits'),
+                              ('apHist', '@apgprefix', {'apred': 'r12', 'mjd': '52123', 'chip':'b', 'instrument': 'apogee-n'},
+                               'r12/exposures/apogee-n/52123/apHist-b-52123.fits')],
+                             ids=['configgrp', 'apgprefix-apo', 'apgprefix-lco', 'apgprefix-ins'])
+    def test_special_function(self, path, name, special, keys, exp):
+        assert special in path.templates[name]
+        full = path.full(name, **keys)
+        assert exp in full
+
     def test_netloc(self, path):
         assert path.netloc == 'data.sdss5.org'
 


### PR DESCRIPTION
This PR adds tests for the recent `configgrp` change, fixes some other apogee tests that broke, and updates the changelog in prep for a new release.