### PR TITLE
Add component_default special function for mwmVisit/mwmStar products

### DIFF
--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -330,6 +330,8 @@ class BasePath(object):
             template = re.sub('@configgrp[|]', '{configgrp}', template)
         if re.search('@plateid6[|]', template):
             template = re.sub('@plateid6[|]', '{plateid:0>6}', template)
+        if re.search('@component_default[|]', template):
+            template = re.sub('@component_default[|]', '{component_default}', template)
 
         # check if template has any brackets
         haskwargs = re.search('[{}]', template)
@@ -1211,6 +1213,38 @@ class Path(BasePath):
         subdir = "{:d}".format(healpix // 1000)
         return subdir
 
+    def component_default(self, filetype, **kwargs):
+        ''' Return the component name, if given.
+
+        The component designates a stellar or planetary body following the 
+        Washington Multiplicity Catalog, which was adopted by the XXIV meeting
+        of the International Astronomical Union. When no component is given,
+        the star is assumed to be without a discernible companion. When a
+        component is given it follows the system (Hessman et al., arXiv:1012.0707):
+
+        – the brightest component is called “A”, whether it is initially resolved 
+          into sub-components or not;
+        – subsequent distinct components not contained within “A” are labeled “B”, 
+          “C”, etc.;
+        – sub-components are designated by the concatenation of on or more suffixes 
+          with the primary label, starting with lowercase letters for the 2nd 
+          hierarchical level and then with numbers for the 3rd.
+        
+        Parameters
+        ----------
+        filetype : str
+            File type parameter. This argument is not used here, but is required for 
+            all special functions in the `sdss_access` product.
+        component : str [optional]
+            The component name as given by the fields.
+        
+        Returns
+        -------
+        component : str
+            The component name if given, otherwise a blank string.
+        '''
+        return kwargs.get('component', '')
+        
     def apgprefix(self, filetype, **kwargs):
         ''' Returns APOGEE prefix using telescope/instrument.
 

--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -332,6 +332,8 @@ class BasePath(object):
             template = re.sub('@plateid6[|]', '{plateid:0>6}', template)
         if re.search('@component_default[|]', template):
             template = re.sub('@component_default[|]', '{component_default}', template)
+        if re.search('@catalogid_groups[|]', template):
+            template = re.sub('@catalogid_groups[|]', '{catalogid_groups}', template)
 
         # check if template has any brackets
         haskwargs = re.search('[{}]', template)
@@ -1212,6 +1214,26 @@ class Path(BasePath):
         healpix = int(kwargs['healpix'])
         subdir = "{:d}".format(healpix // 1000)
         return subdir
+
+    def catalogid_groups(self, filetype, **kwargs):
+        ''' 
+        Return a folder structure to group data together based on their catalog
+        identifier so that we don't have too many files in any one folder.
+        
+        Parameters
+        ----------
+        filetype : str
+            File type parameter.
+        catalogid : int or str
+            SDSS-V catalog identifier
+        
+        Returns
+        -------
+        catalogid_group : str
+            A set of folders.
+        '''
+        catalogid = int(kwargs['catalogid'])
+        return f"{catalogid % 10000:.0f}/{catalogid % 100:.0f}"
 
     def component_default(self, filetype, **kwargs):
         ''' Return the component name, if given.

--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -1243,8 +1243,9 @@ class Path(BasePath):
         component : str
             The component name if given, otherwise a blank string.
         '''
-        return kwargs.get('component', '')
-        
+        # the (..) or '' resolves None to ''
+        return str(kwargs.get('component', '') or '')
+
     def apgprefix(self, filetype, **kwargs):
         ''' Returns APOGEE prefix using telescope/instrument.
 

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -98,6 +98,14 @@ class TestPath(object):
         assert out == exp
 
     @pytest.mark.parametrize('key, val, exp',
+                             [('catalogid', '213948712937684123', '123/23'),
+                              ('catalogid', 213948712937684123, '123/23')])
+    def test_catalogid_groups(self, path, key, val, exp):
+        out = path.catalogid_groups('', **{key: val})
+        assert out == exp
+    
+
+    @pytest.mark.parametrize('key, val, exp',
                              [('component', None, ''),
                               ('component', 'A', 'A'),
                               ('component', 'B', 'B'),

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -97,6 +97,21 @@ class TestPath(object):
         out = path.healpixgrp('', **{key: val})
         assert out == exp
 
+    @pytest.mark.parametrize('key, val, exp',
+                             [('component', None, ''),
+                              ('component', 'A', 'A'),
+                              ('component', 'B', 'B'),
+                              ('component', 'Ca', 'Ca'),
+                              # If component not given, return ''
+                              ('some_other_kwd', 'any_value', ''),
+                              # This convention is against WMC, but the path
+                              # definition will be forgiving and resolve to string.                              
+                              ('component', 1, '1'),
+                              ('component', 0, '0')])
+    def test_component_default(self, path, key, val, exp):
+        out = path.component_default('', **{key: val})
+        assert out == exp
+
     def test_envvar_expansion(self, path):
         name = 'mangacube'
         assert '$MANGA_SPECTRO_REDUX' in path.templates[name]


### PR DESCRIPTION
This PR adds handling for a special function (`component_default`) for mwmVisit/mwmStar products.

It is related to the path definitions pull request, which is here: https://github.com/sdss/tree/pull/43

The PR includes tests for the added function. 