### PR TITLE
Fixing broken tests and mwm paths

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.3dev
+current_version = 2.0.4dev
 commit = True
 tag = False
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.4
+current_version = 2.0.5dev
 commit = True
 tag = False
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.4dev
+current_version = 2.0.4
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ Change Log
 
 This document records the main changes to the sdss_access code.
 
+2.0.4 (2022-11-30)
+------------------
+- Fixing broken tests with MWM paths
+
 2.0.3 (2022-10-15)
 ------------------
 - Minor path fixes for MWM and Astra paths

--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -1220,17 +1220,17 @@ class Path(BasePath):
         return subdir
 
     def cat_id_groups(self, filetype, **kwargs):
-        ''' 
+        '''
         Return a folder structure to group data together based on their catalog
         identifier so that we don't have too many files in any one folder.
-        
+
         Parameters
         ----------
         filetype : str
             File type parameter.
         cat_id : int or str
             SDSS-V catalog identifier
-        
+
         Returns
         -------
         catalogid_group : str
@@ -1238,41 +1238,46 @@ class Path(BasePath):
         '''
         # with k = 100 then even with 10 M sources, each folder will have ~1,000 files
         k = 100
-        cat_id = int(kwargs['cat_id'])
+        if 'cat_id' in kwargs:
+            cat_id = int(kwargs['cat_id'])
+        elif 'catid' in kwargs:
+            cat_id = int(kwargs['catid'])
         return f"{(cat_id // k) % k:0>2.0f}/{cat_id % k:0>2.0f}"
 
     def component_default(self, filetype, **kwargs):
         ''' Return the component name, if given.
 
-        The component designates a stellar or planetary body following the 
+        The component designates a stellar or planetary body following the
         Washington Multiplicity Catalog, which was adopted by the XXIV meeting
         of the International Astronomical Union. When no component is given,
         the star is assumed to be without a discernible companion. When a
         component is given it follows the system (Hessman et al., arXiv:1012.0707):
 
-        – the brightest component is called “A”, whether it is initially resolved 
+        – the brightest component is called “A”, whether it is initially resolved
           into sub-components or not;
-        – subsequent distinct components not contained within “A” are labeled “B”, 
+        – subsequent distinct components not contained within “A” are labeled “B”,
           “C”, etc.;
-        – sub-components are designated by the concatenation of on or more suffixes 
-          with the primary label, starting with lowercase letters for the 2nd 
+        – sub-components are designated by the concatenation of on or more suffixes
+          with the primary label, starting with lowercase letters for the 2nd
           hierarchical level and then with numbers for the 3rd.
-        
+
         Parameters
         ----------
         filetype : str
-            File type parameter. This argument is not used here, but is required for 
+            File type parameter. This argument is not used here, but is required for
             all special functions in the `sdss_access` product.
         component : str [optional]
             The component name as given by the fields.
-        
+
         Returns
         -------
         component : str
             The component name if given, otherwise a blank string.
         '''
         # the (..) or '' resolves None to ''
-        return str(kwargs.get('component', '') or '')
+        # integer 0 resolves to '', i.e. 0 or '' evaluates as None; making check explicit
+        comp = kwargs.get('component', '')
+        return str(comp) if comp is not None else ''
 
     def apgprefix(self, filetype, **kwargs):
         ''' Returns APOGEE prefix using telescope/instrument.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-access
-version = 2.0.4
+version = 2.0.5dev
 author = Brian Cherinka
 author_email = bcherinka@stsci.edu
 description = Package to dynamically build filepaths and access all SDSS SAS products

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-access
-version = 2.0.3dev
+version = 2.0.4dev
 author = Brian Cherinka
 author_email = bcherinka@stsci.edu
 description = Package to dynamically build filepaths and access all SDSS SAS products

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-access
-version = 2.0.4dev
+version = 2.0.4
 author = Brian Cherinka
 author_email = bcherinka@stsci.edu
 description = Package to dynamically build filepaths and access all SDSS SAS products

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -98,13 +98,13 @@ class TestPath(object):
         assert out == exp
 
     @pytest.mark.parametrize('key, val, exp',
-                             [('catalogid', '213948712937684123', '41/23'),
-                              ('catalogid', 213948712937684123, '41/23'),
-                              ('catalogid', 106, '01/06')])
+                             [('catid', '213948712937684123', '41/23'),
+                              ('cat_id', 213948712937684123, '41/23'),
+                              ('cat_id', 106, '01/06')])
     def test_catalogid_groups(self, path, key, val, exp):
-        out = path.catalogid_groups('', **{key: val})
+        out = path.cat_id_groups('', **{key: val})
         assert out == exp
-    
+
 
     @pytest.mark.parametrize('key, val, exp',
                              [('component', None, ''),
@@ -114,9 +114,10 @@ class TestPath(object):
                               # If component not given, return ''
                               ('some_other_kwd', 'any_value', ''),
                               # This convention is against WMC, but the path
-                              # definition will be forgiving and resolve to string.                              
+                              # definition will be forgiving and resolve to string.
                               ('component', 1, '1'),
-                              ('component', 0, '0')])
+                              ('component', 0, '0'),
+                              ('component', None, '')])
     def test_component_default(self, path, key, val, exp):
         out = path.component_default('', **{key: val})
         assert out == exp

--- a/tests/path/test_sdss5.py
+++ b/tests/path/test_sdss5.py
@@ -31,7 +31,7 @@ class TestSVPaths(object):
                              [('apStar', '@healpixgrp',
                                {'apred': 'r12', 'apstar': 'stars', 'telescope': 'apo25m',
                                 'healpix': '12345', 'obj': '12345'},
-                               'r12/stars/apo25m/12/12345/apStar-r12-apo25m-12345.fits')],
+                               'r12/apo25m/12/12345/apStar-r12-apo25m-12345.fits')],
                              ids=['apStar'])
     def test_apogee_paths(self, path, name, special, keys, exp):
         assert special in path.templates[name]


### PR DESCRIPTION
This PR fixes broken tests, some issues with MWM paths.  It also corrects the broken version with the 2.0.3 tag, releases a new 2.0.4 patch, bumps the main version to 2.0.5dev. 