### PR TITLE
Add new configsubmodule function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ Change Log
 
 This document records the main changes to the sdss_access code.
 
+Next release
+------------
+
+- Adds new `configsubmodule` special function.
+
 2.0.5 (2022-11-30)
 ------------------
 - Bug fix for downloading IPL-1 products with sdss_access
@@ -179,4 +184,3 @@ Added
 Changed
 ^^^^^^^
 * Migrated sdss_access over into the cookiecutter model
-

--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -1362,6 +1362,28 @@ class Path(BasePath):
             return '0000XX'
         return '{:0>4d}XX'.format(int(configid) // 100)
 
+    def configsubmodule(self, filetype, **kwargs):
+        ''' Returns configuration summary submodule group subdirectory
+
+        Parameters
+        ----------
+        filetype : str
+            File type parameter.
+        configid : int or str
+            Configuration ID number.  Will be converted to int internally.
+
+        Returns
+        -------
+        configsubmodule : str
+            Configuration submodule directory in the format ``NNNXXX``.
+
+        '''
+
+        configid = kwargs.get('configid', None)
+        if not configid:
+            return '000XXX'
+        return '{:0>3d}XXX'.format(int(configid) // 1000)
+
     def isplate(self, filetype, **kwargs):
         ''' Returns the plate flag for BOSS idlspec2d run2d versions that utilize it
 


### PR DESCRIPTION
Adds a new function `configsubmodule` that generates `098XXX`-like templates for the new `sdsscore` directory structure.