### PR TITLE
Refactors sdss_access for new tree

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0
+current_version = 3.0.1dev
 commit = True
 tag = False
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.6
+current_version = 3.0.0dev
 commit = True
 tag = False
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0dev
+current_version = 3.0.0
 commit = True
 tag = False
 tag_name = {new_version}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
@@ -39,6 +39,9 @@ jobs:
         machine: data.sdss5.org
         username: ${{ secrets.S5_USERNAME }}
         password: ${{ secrets.S5_PASSWORD }}
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,6 @@ jobs:
         username: ${{ secrets.S5_USERNAME }}
         password: ${{ secrets.S5_PASSWORD }}
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -44,3 +44,8 @@ jobs:
       run: |
         pip install pytest
         pytest
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Change Log
 
 This document records the main changes to the sdss_access code.
 
-3.0.0 (unreleased)
+3.0.0 (2023-06-05)
 ------------------
 - Fixing sdss_access after `tree` updates.  "sdsswork" now references SDSS-V paths.
 - Pins `tree` package to `>4.0`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ This document records the main changes to the sdss_access code.
 
 3.0.0 (unreleased)
 ------------------
-- Fixing sdss_access after `tree` updates
+- Fixing sdss_access after `tree` updates.  "sdsswork" now references SDSS-V paths.
 - Pins `tree` package to `>4.0`
 - Adds new pattern for detecting required keywords in special functions
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ Change Log
 
 This document records the main changes to the sdss_access code.
 
+3.0.0 (unreleased)
+------------------
+- Fixing sdss_access after `tree` updates
+- Pins `tree` package to `>4.0`
+- Adds new pattern for detecting required keywords in special functions
+
 2.0.6 (2023-06-02)
 ------------------
 - Adds new `configsubmodule` special function.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,42 @@ are dynamically constructed given a minimal name and set of keywords to be subst
 can also be downloaded programmatically using an ``Access`` class which provides streaming downloads via ``rysnc`` or ``curl``
 depending on your OS. See the full documentation at http://sdss-access.readthedocs.io/en/latest/
 
-Useful links
-------------
+## Developer Install
+
+To install `sdss_access` for development locally:
+
+```
+git clone https://github.com/sdss/sdss_access
+cd sdss_acccess
+pip install -e ".[dev,docs]"
+```
+
+## Build Sphinx Docs
+
+Within the top level repo directory, run the `sdsstools` commands:
+```
+# build the Sphinx documentation
+sdss docs.build
+
+# open the docs locally in a browser
+sdss docs.show
+```
+Documentation is automatically built and pushed to Read The Docs.
+
+## Testing
+Tests are created using `pytest`.  Navigate to the `tests` directory from the top level and run with `pytest`.
+```
+cd tests
+pytest
+```
+
+## Creating Releases
+
+New releases of `sdss-access` are created automatically, and pushed to [PyPi](https://pypi.org/project/sdss-access/), when new tags are pushed to Github.  See the [Create Release](.github/workflows/release.yml) Github Action and [Releases](https://github.com/sdss/sdss_access/releases) for the list.
+
+New tag names follow the Python semantic versioning syntax, i.e. `X.Y.Z`.
+
+# Useful links
 
 - GitHub: https://github.com/sdss/sdss_access
 - Documentation: https://sdss-access.readthedocs.org

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ![Versions](https://img.shields.io/badge/python->3.7-blue)
 [![Documentation Status](https://readthedocs.org/projects/sdss-access/badge/?version=latest)](https://sdss-access.readthedocs.io/en/latest/?badge=latest)
+[![Build Sphinx Documentation](https://github.com/sdss/sdss_access/actions/workflows/sphinxbuild.yml/badge.svg)](https://github.com/sdss/sdss_access/actions/workflows/sphinxbuild.yml)
 [![Build and Test](https://github.com/sdss/sdss_access/actions/workflows/build.yml/badge.svg)](https://github.com/sdss/sdss_access/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/sdss/sdss_access/branch/master/graph/badge.svg)](https://codecov.io/gh/sdss/sdss_access)
-[![Coveralls](https://coveralls.io/repos/github/sdss/sdss_access/badge.svg)](https://coveralls.io/github/sdss/sdss_access)
 
 
 This products allows for dynamically building filepaths to SDSS data products hosted on the Science Archive Server (SAS).  Filepaths

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -74,7 +74,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/sphinx/intro.rst
+++ b/docs/sphinx/intro.rst
@@ -105,6 +105,23 @@ the ``remote`` keyword argument
     path.exists('mangacube', drpver='v3_1_1', plate='8485', ifu='1901', wave='LOG', remote=True)
     True
 
+Required Keywords
+-----------------
+
+All the keyword variables defined in a **path_template**, and returned by `Path.lookup_keys <.BasePath.lookup_keys>`,
+are required.  Not specifying all the keywords will result in an error raised.
+
+::
+
+    >>> path = Path(release='dr17')
+
+    >>> # see the required keys
+    >>> path.lookup_keys('mangacube')
+    ['plate', 'drpver', 'wave', 'ifu']
+
+    >>> path.full('mangacube', drpver='v3_1_1', plate='8485', ifu='1901')
+    KeyError: "Missing required keyword arguments: ['wave']"
+
 Environment Paths
 -----------------
 
@@ -163,6 +180,23 @@ Alternatively, you can permanently set a subset of environment variables to pres
     preserve_envvars:
       - ROBOSTRATEGY_DATA
       - ALLWISE_DIR
+
+Extracting Keywords from Filepaths
+----------------------------------
+
+You can extract the keyword variables from a specific filepath, by using the `Path.extract <.BasePath.extract>` method
+and specifying the **path_name** reference, and the full filepath.  For the extraction to work, the path to the file
+must match the SAS directory structure, and have the relevant environment variable defined from the **path_template**.
+::
+
+    >>> # set a path to a file
+    >>> filepath = '/Users/Brian/Work/sdss/sas/dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
+
+    >>> # extract the keywords
+    >>> path = Path(release='dr17')
+    >>> path.extract('mangacube', filepath)
+    {'drpver': 'v3_1_1', 'plate': '8485', 'ifu': '1901', 'wave': 'LOG'}
+
 
 Downloading Files
 -----------------

--- a/docs/sphinx/intro.rst
+++ b/docs/sphinx/intro.rst
@@ -7,6 +7,27 @@ Introduction to sdss_access
 SDSS Access provides a convenient way of navigating local and remote filesystem paths from the Science Archive Server (SAS).
 ``sdss_access`` uses the SDSS Tree product for all path look-ups.
 
+Concept
+-------
+
+SDSS Access works with abstract filepaths to data products, as a way of easily generating paths to specific data products.
+An abstract filepath is a generalized path that represents the path to the data product or `file_species`, and can be
+resolved to an example of any individual file of that "file_species".  A abstract path is defined by:
+
+* **path_name**: a reference name to the data product or `file_species`
+* **path_template**: a string filepath starting with an environment variable, and using {} templating for keyword variable replacement
+
+These paths are defined in the tree product as `path_name = path_template`. See
+`Defining New Paths <https://sdss-tree.readthedocs.io/en/latest/paths.html>`_ for more info.
+For example, the abstract path for the MaNGA cube data products is
+::
+
+    # path_name = path_template
+    mangacube = '$MANGA_SPECTRO_REDUX/{drpver}/{plate}/stack/manga-{plate}-{ifu}-{wave}CUBE.fits.gz'
+
+The variable names within the `{}` are specified at runtime to create a path to a specific file on disk.
+
+
 Path Generation
 ---------------
 
@@ -14,29 +35,29 @@ You can generate full paths to local files easily with `Path.full <.BasePath.ful
 ::
 
     # import the path
-    from sdss_access import SDSSPath
-    path = SDSSPath()
+    from sdss_access import Path
+    path = Path(release='dr17')
 
     # generate a file system path
-    path.full('mangacube', drpver='v2_3_1', plate='8485', ifu='1901', wave='LOG')
-    '/Users/Brian/Work/sdss/sas/mangawork/manga/spectro/redux/v2_3_1/8485/stack/manga-8485-1902-LOGCUBE.fits.gz'
+    path.full('mangacube', drpver='v3_1_1', plate='8485', ifu='1901', wave='LOG')
+    '/Users/Brian/Work/sdss/sas/dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
 
 Note that this only generates a path. The file may not actually exist locally.  If you want to generate a URL path to
 the file on the SAS at Utah, you can use `Path.url <.BasePath.url>`.
 ::
 
     # generate a http path to the file
-    path.url('mangacube', drpver='v2_3_1', plate='8485', ifu='1901', wave='LOG')
-    'https://data.sdss.org/sas/mangawork/manga/spectro/redux/v2_3_1/8485/stack/manga-8485-1902-LOGCUBE.fits.gz'
+    path.url('mangacube', drpver='v3_1_1', plate='8485', ifu='1901', wave='LOG')
+    'https://data.sdss.org/sas/dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
 
 You can also pass in the full path directly as a string in cases.  In those cases, the first argument passed in must
 be an empty string.
 ::
 
     # pass in the full path directly to path.url
-    full = path.full('mangacube', drpver='v2_3_1', plate='8485', ifu='1901', wave='LOG')
+    full = path.full('mangacube', drpver='v3_1_1', plate='8485', ifu='1901', wave='LOG')
     path.url('', full=full)
-    'https://data.sdss.org/sas/mangawork/manga/spectro/redux/v2_3_1/8485/stack/manga-8485-1902-LOGCUBE.fits.gz'
+    'https://data.sdss.org/sas/dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
 
 Path Names
 ----------
@@ -48,8 +69,8 @@ defined in the path ``$MANGA_SPECTRO_REDUX/{drpver}/{plate}/stack/manga-{plate}-
 are defined inside the SDSS ``tree`` product, within a `[PATHS]` section in the environment configuration files, e.g. `data/sdsswork.cfg`
 or `data/dr15.cfg`.  Within ``sdss_access``, all paths are available as a dictionary, ``path.templates``::
 
-    from sdss_access.path import SDSSPath
-    path = SDSSPath()
+    from sdss_access.path import Path
+    path = Path(release='dr17')
 
     # show the dictionary of available paths
     path.templates
@@ -77,11 +98,11 @@ the ``remote`` keyword argument
 ::
 
     # check for local path existence
-    path.exists('mangacube', drpver='v2_3_1', plate='8485', ifu='1901', wave='LOG')
+    path.exists('mangacube', drpver='v3_1_1', plate='8485', ifu='1901', wave='LOG')
     True
 
     # check for remote path existence on the SAS
-    path.exists('mangacube', drpver='v2_3_1', plate='8485', ifu='1901', wave='LOG', remote=True)
+    path.exists('mangacube', drpver='v3_1_1', plate='8485', ifu='1901', wave='LOG', remote=True)
     True
 
 Environment Paths
@@ -96,23 +117,23 @@ paths relevant to that environment.
     >>> from sdss_access.path import Path
     >>> path = Path()
     >>> path
-    <Path(release="sdsswork", public=False, n_paths=358)
+    <Path(release="sdsswork", public=False, n_paths=233)
 
 To access paths from a different environment, you can change environments by passing in the ``release`` keyword argument.  The
 ``release`` acts as an indicator for both a valid data release, e.g. "DR15", and a valid environment configuration,
 e.g. "sdsswork".
 ::
 
-    >>> # load the sdss5 environment and paths
+    >>> # load the SDSS-V environment and paths
     >>> from sdss_access.path import Path
-    >>> path = Path(release='sdss5')
+    >>> path = Path(release='sdsswork')
     >>> path
-    <Path(release="sdss5", public=False, n_paths=97)
+    <Path(release="sdsswork", public=False, n_paths=233)
 
-    >>> # switch to the environment for public data release DR15
-    >>> path = Path(release='DR15')
+    >>> # switch to the environment for public data release DR17
+    >>> path = Path(release='DR17')
     >>> path
-    <Path(release="dr15", public=True, n_paths=325)
+    <Path(release="dr17", public=True, n_paths=420)
 
 When reloading a new ``tree`` environment configuration, ``sdss_access`` automatically updates the Python session
 ``os.environ`` with the relevant environment variables for the given release/configuration.  You can preserve your original
@@ -120,15 +141,15 @@ When reloading a new ``tree`` environment configuration, ``sdss_access`` automat
 entirety.
 ::
 
-    >>> # load the sdss5 environment but preserve your original os.environ
-    >>> path = Path(release='sdss5', preserve_envvars=True)
+    >>> # load the SDSS-V environment but preserve your original os.environ
+    >>> path = Path(release='sdsswork', preserve_envvars=True)
 
 Alternatively, you can preserve a subset of enviroment variables from your original ``os.environ`` by passing in a list of
 environment variables.
 ::
 
     >>> # preserve only a single environment variable
-    >>> path = Path(release='sdss5', preserve_envvars=['ROBOSTRATEGY_DATA'])
+    >>> path = Path(release='sdsswork', preserve_envvars=['ROBOSTRATEGY_DATA'])
 
 If you wish to permanently preserve your locally set environment variables, you can set the ``preserve_envvars`` parameter to
 ``true`` in a custom tree YAML configuration file located at ``~/.config/sdss/sdss_access.yml``.  For example
@@ -150,7 +171,7 @@ You can download files from the SAS and place them in your local SAS.  ``sdss_ac
 that mimics the real SAS at Utah.  If you do not already have a `SAS_BASE_DIR` set, one will be defined in your
 home directory, as a new ``sas`` directory.
 
-``sdss_access`` requires valid authentication to download proprietary data.  See :ref:`auth` 
+``sdss_access`` requires valid authentication to download proprietary data.  See :ref:`auth`
 for more information.
 
 sdss_access has four classes designed to facilitate access to SAS data.
@@ -168,13 +189,13 @@ Using the `.HttpAccess` class.
 ::
 
     from sdss_access import HttpAccess
-    http_access = HttpAccess(verbose=True)
+    http_access = HttpAccess(release='DR17', verbose=True)
 
     # set to use remote
     http_access.remote()
 
     # get the file
-    http_access.get('mangacube', drpver='v2_3_1', plate='8485', ifu='1901', wave='LOG')
+    http_access.get('mangacube', drpver='v3_1_1', plate='8485', ifu='1901', wave='LOG')
 
 Using the `.RsyncAccess` class.  `.RsyncAccess` is generally much faster then `.HttpAccess` as it spreads multiple
 file downloads across multiple continuous rsync download streams.
@@ -183,14 +204,14 @@ file downloads across multiple continuous rsync download streams.
 
     # import the rsync class
     from sdss_access import RsyncAccess
-    rsync = RsyncAccess()
+    rsync = RsyncAccess(release='DR17')
 
     # sets a remote mode to the real SAS
     rsync.remote()
 
     # add all the file(s) you want to download
-    # let's download all MPL-6 MaNGA cubes for plate 8485
-    rsync.add('mangacube', drpver='v2_3_1', plate='8485', ifu='*', wave='LOG')
+    # let's download all DR17 MaNGA cubes for plate 8485
+    rsync.add('mangacube', drpver='v3_1_1', plate='8485', ifu='*', wave='LOG')
 
     # set the stream tasks
     rsync.set_stream()
@@ -198,21 +219,13 @@ file downloads across multiple continuous rsync download streams.
     # start the download(s)
     rsync.commit()
 
-The default mode of `.RsyncAccess` is for collaboration access.  You can also access data from publicly available
-SDSS data releases, by specifying the ``public`` and ``release`` keyword arguments on init.
-
-::
-
-    # setup rsync access to download public data from DR14
-    rsync = RsyncAccess(public=True, release='dr14')
-
 Using the `.CurlAccess` class.  `.CurlAccess` behaves exactly the same way as `.RsyncAccess`.  After importing and
 instantiating a `.CurlAccess` object, all methods and behavior are the same as in the `.RsyncAccess` class.
 ::
 
     # import the curl class
     from sdss_access import CurlAccess
-    curl = CurlAccess()
+    curl = CurlAccess(release='DR17')
 
 Using the `.Access` class.  Depending on your operating system, ``posix`` or not, Access will either create itself using
 `.RsyncAccess` or `.CurlAccess`, and behave as either object.  Via `.Acccess`, Windows machines will always use `.CurlAccess`,
@@ -221,7 +234,7 @@ while Linux or Macs will automatically utilize `.RsyncAccess`.
 
     # import the access class
     from sdss_access import Access
-    access = Access()
+    access = Access(release='DR17')
 
     # the access mode is automatically set to rsync.
     print(access)
@@ -230,7 +243,7 @@ while Linux or Macs will automatically utilize `.RsyncAccess`.
     # the class now behaves exactly like RsyncAccess.
     # download a MaNGA cube
     access.remote()
-    access.add('mangacube', drpver='v2_3_1', plate='8485', ifu='1901')
+    access.add('mangacube', drpver='v3_1_1', plate='8485', ifu='1901')
     access.set_stream()
     access.commit()
 
@@ -241,57 +254,61 @@ files within the temporary directory.
 Accessing SDSS-V Products
 -------------------------
 
-As of version 2.0.0, ``sdss_access`` has been updated to support downloading of 
-SDSS-V products.  The usage of ``sdss_access`` remains the same.  The only difference is SDSS-V 
-products are now delivered by the "data.sdss5.org" server instead of "data.sdss.org".  
+With SDSS-V, the usage of ``sdss_access`` remains the same.  The only difference is SDSS-V
+products are now delivered by the "data.sdss5.org" server instead of "data.sdss.org".
 When specifying ``release="sdss5"``, you may notice the new server location, e.g.
 ::
 
     >>> from sdss_access import Access
-    >>> access = Access(release='sdss5')
+    >>> access = Access()
     >>> access
     <Access(access_mode="rsync", using="data.sdss5.org")>
 
-As with SDSS-IV, ``sdss_access`` requires valid authentication to download 
+As with SDSS-IV, ``sdss_access`` requires valid authentication to download
 proprietary data for SDSS-V.  See :ref:`auth` for more information.  Here is an example accessing
 the robostrategy completeness files for SDSS-V.
 
 .. warning::
-    The below example contains large data, ~8 GB, and may take a while to download.    
+    The below example contains large data, ~8 GB, and may take a while to download.
 
 ::
 
     from sdss_access import Access
-    access = Access(release='sdss5')
+    access = Access()
     access.remote()
     access.add('rsCompleteness', observatory='apo', plan='epsilon-2-core-*')
     access.set_stream()
     access.commit()
 
+.. note::
+    As of ``version >= 3.0.0``, and ``tree >= 4.0.0`` the default config of "sdsswork" is for SDSS-V
+    data products.  In ``versions >2.0 - <3.0``, the "sdsswork" config is for SDSS-V data products, and SDSS-V
+    data products can be accessed using the "sdss5" config or release name.
 
 Accessing Public Data Products
 ------------------------------
 
 The default configuration of all ``sdss_access`` classes, i.e. ``Path``, ``Access``, ``RsyncAccess``, etc. is to use the
-``sdsswork`` environment configuration, for access to the most up-to-date filepaths.  To specify paths, or download files, of products from public
-data releases, specify the ``release`` keyword and/or the ``public`` keyword.  ``sdss_access`` will automatically set ``public=True`` when the
-input release contains ``DRXX``.  You can also explicitly set the ``public`` keyword.
+``sdsswork`` environment configuration, for access to proprietary data or up-to-date filepaths.  To specify paths,
+or download files, of products from public data releases, specify the ``release`` keyword.  ``sdss_access`` will
+automatically set ``public=True`` when the input release contains ``DRXX``.  You can also explicitly set
+the ``public`` keyword.
 ::
 
-    # import the path and set it to use the DR15 release
+    # import the path and set it to use the DR17 release
     from sdss_access.path import Path
-    path = Path(release='DR15')
+    path = Path(release='DR17')
 
     # check if a public path
     path.public
     True
 
     # generate a file system path
-    path.full('mangacube', drpver='v2_4_3', plate=8485, ifu=1901, wave='LOG')
-    '/Users/Brian/Work/sdss/sas/dr15/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
+    path.full('mangacube', drpver='v3_1_1', plate=8485, ifu=1901, wave='LOG')
+    '/Users/Brian/Work/sdss/sas/dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
 
-    # setup rsync access to download public data from DR15
-    rsync = RsyncAccess(public=True, release='DR15')
+    # setup rsync access to download public data from DR17
+    rsync = RsyncAccess(public=True, release='DR17')
 
 .. _sdss-access-svn:
 
@@ -308,22 +325,13 @@ it uses the local path definition, and for urls, it uses the correct ``svn.sdss.
 
     from sdss_access.path import Path
 
-    # load the paths for sdsswork
-    path = Path()
+    # load the paths for DR17
+    path = Path(release='DR17')
     path.full('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007')
-    '/Users/Brian/Work/sdss/data/manga/mangapreim/trunk/data/D0084XX/8405/preimage-1-42007_irg.jpg'
+    '/Users/Brian/Work/sdss/data/manga/mangapreim/v2_9/data/D0084XX/8405/preimage-1-42007_irg.jpg'
 
     path.url('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007')
-    'https://svn.sdss.org/data/manga/mangapreim/trunk/data/D0084XX/tags/8405/preimage-1-42007_irg.jpg'
-
-
-    # load the paths for DR15
-    path = Path(release='DR15')
-    path.full('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007')
-    '/Users/Brian/Work/sdss/data/manga/mangapreim/v2_5/data/D0084XX/8405/preimage-1-42007_irg.jpg'
-
-    path.url('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007')
-    'https://svn.sdss.org/public/data/manga/mangapreim/tags/v2_5/data/D0084XX/8405/preimage-1-42007_irg.jpg'
+    'https://svn.sdss.org/public/data/manga/mangapreim/tags/v2_9/data/D0084XX/8405/preimage-1-42007_irg.jpg'
 
 As always, paths generated by ``tree`` and ``sdss_access`` use the directory structure as it exists on the SDSS
 Science Archive Server (SAS).  The same is true for paths defined for SVN data files, using the directory structure
@@ -337,15 +345,15 @@ the ``mangapreim`` SVN data product is installed locally.
     ----------------------------------------------------------- /Users/Brian/Work/sdss/data/modulefiles ------------------------------------------------------------
     mangapreim/trunk(default)
 
-However, the DR15 generated ``mangapreimg`` path will be the offical tag of the product for DR15, ``v2_5``, which does not
+However, the DR17 generated ``mangapreimg`` path will be the offical tag of the product for DR17, ``v2_9``, which does not
 exist locally.  You can always override the generated path to use your local module environment by setting
 the ``force_module`` keyword.
 ::
 
-    # load the paths for DR15
-    path = Path(release='DR15')
+    # load the paths for DR17
+    path = Path(release='DR17')
     path.full('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007')
-    '/Users/Brian/Work/sdss/data/manga/mangapreim/v2_5/data/D0084XX/8405/preimage-1-42007_irg.jpg'
+    '/Users/Brian/Work/sdss/data/manga/mangapreim/v2_9/data/D0084XX/8405/preimage-1-42007_irg.jpg'
 
     # Override the path to use my local module
     path.full('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007', force_module=True)
@@ -355,7 +363,7 @@ If you want to always override paths with any local modules found, you can set t
 instantiation.
 ::
 
-    path = Path(release='DR15', force_modules=True)
+    path = Path(release='DR17', force_modules=True)
     path.full('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007')
     '/Users/Brian/Work/sdss/data/manga/mangapreim/trunk/data/D0084XX/8405/preimage-1-42007_irg.jpg'
 

--- a/docs/sphinx/path_defs.rst
+++ b/docs/sphinx/path_defs.rst
@@ -116,96 +116,6 @@ DR8
    :prog: DR8
    :templates:
 
-.. _mpl11:
-
-MPL11
------
-
-.. datamodel:: sdss_access.path.path:Path
-   :prog: MPL11
-   :templates:
-
-.. _mpl10:
-
-MPL10
------
-
-.. datamodel:: sdss_access.path.path:Path
-   :prog: MPL10
-   :templates:
-
-.. _mpl9:
-
-MPL9
-----
-
-.. datamodel:: sdss_access.path.path:Path
-   :prog: MPL9
-   :templates:
-
-.. _mpl8:
-
-MPL8
-----
-
-.. datamodel:: sdss_access.path.path:Path
-   :prog: MPL8
-   :templates:
-
-.. _mpl7:
-
-MPL7
-----
-
-.. datamodel:: sdss_access.path.path:Path
-   :prog: MPL7
-   :templates:
-
-.. _mpl6:
-
-MPL6
-----
-
-.. datamodel:: sdss_access.path.path:Path
-   :prog: MPL6
-   :templates:
-
-.. _mpl5:
-
-MPL5
-----
-
-.. datamodel:: sdss_access.path.path:Path
-   :prog: MPL5
-   :templates:
-
-.. _mpl4:
-
-MPL4
-----
-
-.. datamodel:: sdss_access.path.path:Path
-   :prog: MPL4
-   :templates:
-
-.. _mpl3:
-
-MPL3
-----
-
-.. datamodel:: sdss_access.path.path:Path
-   :prog: MPL3
-   :templates:
-
-.. _sdss5:
-
-SDSS-V
-------
-
-.. datamodel:: sdss_access.path.path:Path
-   :prog: sdss5
-   :templates:
-
 .. _ipl1:
 
 IPL1
@@ -213,4 +123,13 @@ IPL1
 
 .. datamodel:: sdss_access.path.path:Path
    :prog: IPL1
+   :templates:
+
+.. _ipl2:
+
+IPL2
+----
+
+.. datamodel:: sdss_access.path.path:Path
+   :prog: IPL2
    :templates:

--- a/docs/sphinx/path_evolution.rst
+++ b/docs/sphinx/path_evolution.rst
@@ -58,41 +58,6 @@ Internal Product Launches (IPLs)
 
 .. changelog:: sdss_access.path.changelog:compute_changelog
    :prog: changes
-   :drs: ipl1, ipl1
+   :drs: ipl2, ipl1
 
-
-MaNGA Product Launches (MPLs)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. changelog:: sdss_access.path.changelog:compute_changelog
-   :prog: changes
-   :drs: mpl11, mpl10
-
-.. changelog:: sdss_access.path.changelog:compute_changelog
-   :prog: changes
-   :drs: mpl10, mpl9
-
-.. changelog:: sdss_access.path.changelog:compute_changelog
-   :prog: changes
-   :drs: mpl9, mpl8
-
-.. changelog:: sdss_access.path.changelog:compute_changelog
-   :prog: changes
-   :drs: mpl8, mpl7
-
-.. changelog:: sdss_access.path.changelog:compute_changelog
-   :prog: changes
-   :drs: mpl7, mpl6
-
-.. changelog:: sdss_access.path.changelog:compute_changelog
-   :prog: changes
-   :drs: mpl6, mpl5
-
-.. changelog:: sdss_access.path.changelog:compute_changelog
-   :prog: changes
-   :drs: mpl5, mpl4
-
-.. changelog:: sdss_access.path.changelog:compute_changelog
-   :prog: changes
-   :drs: mpl4, mpl3
 

--- a/docs/sphinx/paths.rst
+++ b/docs/sphinx/paths.rst
@@ -10,8 +10,7 @@ Tree <https://sdss-tree.readthedocs.io/en/latest/paths.html>`_ and follow the in
 
 Current Working Paths
 
-* :ref:`sdsswork <sdsswork>` - the latest "working" path definitions
-* :ref:`sdss5<sdss5>` - temporary working paths for SDSS-V
+* :ref:`sdsswork <sdsswork>` - the latest "working" path definitions for SDSS-V
 
 Public Data Release Paths
 
@@ -30,16 +29,7 @@ Public Data Release Paths
 Internal SDSS Release Paths
 
 * :ref:`IPL-1 <ipl1>` - Internal Product Launch 1
-
-* :ref:`MPL-11<mpl11>` - MaNGA Product Launch 11
-* :ref:`MPL-10<mpl10>`
-* :ref:`MPL-9<mpl9>`
-* :ref:`MPL-8<mpl8>`
-* :ref:`MPL-7<mpl7>`
-* :ref:`MPL-6<mpl6>`
-* :ref:`MPL-5<mpl5>`
-* :ref:`MPL-4<mpl4>`
-* :ref:`MPL-3<mpl3>`
+* :ref:`IPL-2 <ipl2>` - Internal Product Launch 2
 
 
 Latest Path Evolution

--- a/python/sdss_access/__init__.py
+++ b/python/sdss_access/__init__.py
@@ -26,9 +26,8 @@ log.debug("SDSS_ACCESS> Using {0}".format(tree))
 config = get_config(NAME)
 
 
-#__version__ = '1.0.0dev'
 __version__ = get_package_version(path=__file__, package_name=NAME)
 
 
-from .path import Path as SDSSPath, AccessError
+from .path import Path, AccessError
 from .sync import HttpAccess, Access, BaseAccess, RsyncAccess, CurlAccess

--- a/python/sdss_access/path/changelog.py
+++ b/python/sdss_access/path/changelog.py
@@ -41,9 +41,7 @@ def compute_changelog(new, old, pprint=None, to_list=None):
         A dictionary of relevant changes between the two releases
     '''
 
-    diffs = compute_path_changes(new, old, pprint=pprint, paths_only=True, to_list=to_list)
-
-    return diffs
+    return compute_path_changes(new, old, pprint=pprint, paths_only=True, to_list=to_list)
 
 
 def get_path_templates(name, public=None):

--- a/python/sdss_access/path/changelog.py
+++ b/python/sdss_access/path/changelog.py
@@ -64,7 +64,7 @@ def get_path_templates(name, public=None):
     versions = {}
     for release in reversed(releases):
         release = 'sdsswork' if 'WORK' in release else release
-        tree = Tree(config=release)
+        tree = Tree(config=release.lower())
         versions[release] = tree.paths.get(name, None)
     return versions
 

--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -100,7 +100,7 @@ class BasePath(object):
 
     _netloc = {"dtn": "dtn.sdss.org", "sdss": "data.sdss.org", "sdss5": "data.sdss5.org",
                "mirror": "data.mirror.sdss.org", "svn": "svn.sdss.org"}
-    _s5cfgs = ['sdss5', 'ipl1']  # list of collab-only SDSS-V releases/configs
+    _s5cfgs = ['sdsswork', 'sdss5', 'ipl1']  # list of collab-only SDSS-V releases/configs
 
     def __init__(self, release=None, public=False, mirror=False, verbose=False,
                  force_modules=None, preserve_envvars=None):

--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -207,10 +207,16 @@ class BasePath(object):
             method = getattr(self, function[1:-1])
             # get source code of special method
             source = self._find_source(method)
-            fkeys = re.findall(r'kwargs\[(.*?)\]', source)
+
+            # matches on kwargs.get("xxx"), kwargs.get("xxx", None), or kwargs["xxx"]
+            # on either single or double quoted string, with or without a default value
+            patt = r"kwargs.get\(\W(\w+)\W,*\s*.*\)|kwargs\[\W(\w+)\W\]"
+            fkeys = re.findall(patt, source)
+
             if fkeys:
-                # evaluate to proper string
-                fkeys = [ast.literal_eval(k) for k in fkeys]
+                # condense gorups down to proper string list
+                fkeys = [str(i) for k in fkeys for i in k if i]
+
                 keys.extend(fkeys)
         return keys
 
@@ -1242,7 +1248,9 @@ class Path(BasePath):
         if 'cat_id' in kwargs:
             cat_id = int(kwargs['cat_id'])
         elif 'catid' in kwargs:
-            cat_id = int(kwargs['catid'])
+            # removing the undesired version as this messes up the lookup_keys method
+            kwargs['cat_id'] = kwargs.pop('catid')
+            cat_id = int(kwargs['cat_id'])
         return f"{(cat_id // k) % k:0>2.0f}/{cat_id % k:0>2.0f}"
 
     def component_default(self, filetype, **kwargs):
@@ -1299,14 +1307,19 @@ class Path(BasePath):
 
         '''
 
-        telescope = kwargs.get('telescope', None)
+        # since telescope or instrument already defined in the main
+        # template for all paths, we rename the kwargs dict so these keywords
+        # do not get picked up by the lookup_keys method.
+        newkw = kwargs.copy()
+
+        telescope = newkw.get('telescope', None)
         if telescope is not None:
             prefix = {'apo25m': 'ap', 'apo1m': 'ap', 'lco25m': 'as'}
             if telescope not in prefix:
                 raise ValueError(f'{telescope} not in allowed list of prefixes')
             return prefix[telescope]
 
-        instrument = kwargs.get('instrument', None)
+        instrument = newkw.get('instrument', None)
         if instrument is not None:
             prefix = {'apogee-n': 'ap', 'apogee-s': 'as'}
             if instrument not in prefix:

--- a/python/sdss_access/sync/baseaccess.py
+++ b/python/sdss_access/sync/baseaccess.py
@@ -4,13 +4,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import abc
 import six
 from os.path import join, sep
-from sdss_access import SDSSPath
+from sdss_access import Path
 from sdss_access.sync.auth import Auth, AuthMixin
 from sdss_access.sync.stream import Stream
 from sdss_access import is_posix, AccessError
 
 
-class BaseAccess(six.with_metaclass(abc.ABCMeta, AuthMixin, SDSSPath)):
+class BaseAccess(six.with_metaclass(abc.ABCMeta, AuthMixin, Path)):
     """Class for providing Rsync or Curl access to SDSS SAS Paths
     """
     remote_scheme = None

--- a/python/sdss_access/sync/http.py
+++ b/python/sdss_access/sync/http.py
@@ -11,12 +11,12 @@ except:
 
 from os import makedirs
 from os.path import isfile, exists, dirname
-from sdss_access import SDSSPath
+from sdss_access import Path
 from sdss_access.sync.auth import Auth, AuthMixin
 from tqdm import tqdm
 
 
-class HttpAccess(AuthMixin, SDSSPath):
+class HttpAccess(AuthMixin, Path):
     """Class for providing HTTP access via urllib.request (python3) or urllib2 (python2) to SDSS SAS Paths
     """
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-access
-version = 2.0.6
+version = 3.0.0dev
 author = Brian Cherinka
 author_email = bcherinka@stsci.edu
 description = Package to dynamically build filepaths and access all SDSS SAS products

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-access
-version = 3.0.0
+version = 3.0.1dev
 author = Brian Cherinka
 author_email = bcherinka@stsci.edu
 description = Package to dynamically build filepaths and access all SDSS SAS products

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-access
-version = 3.0.0dev
+version = 3.0.0
 author = Brian Cherinka
 author_email = bcherinka@stsci.edu
 description = Package to dynamically build filepaths and access all SDSS SAS products

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ package_dir =
 install_requires =
     six>=1.11
     requests>=2.10.0
-    sdss-tree>=3.1.2,<4.0.0
+    sdss-tree>=4.0.0
 	sdsstools>=0.4.5
 	tqdm>=4.46.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,7 +105,7 @@ per-file-ignores =
 max-line-length = 99
 
 [tool:pytest]
-addopts = --cov sdss_access --cov-report html -W ignore
+addopts = --cov sdss_access --cov-report xml --cov-report html --cov-report term -W ignore
 
 [coverage:run]
 branch = true
@@ -114,6 +114,7 @@ include =
 omit =
     */utils/*.py
     */__init__.py
+	*/sync/system_call.py
 
 [coverage:report]
 exclude_lines =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,14 +40,10 @@ def pytest_runtest_setup(item):
 @pytest.fixture()
 def path():
     ''' Fixture to create a generic Path object '''
-    path = Path()
+    path = Path(release='dr17')
     path.replant_tree()
     yield path
     path = None
-
-
-# releases to parametrize over
-releases = ['work', 'DR15']
 
 
 # read in test data parameters and also get paths
@@ -62,12 +58,6 @@ data = get_data()
 paths = data.get('paths')
 
 
-@pytest.fixture(scope='session', params=releases)
-def release(request):
-    ''' release fixture '''
-    return request.param
-
-
 @pytest.fixture(scope='session', params=paths)
 def datapath(request):
     ''' parametrizes over the paths in test data'''
@@ -75,13 +65,13 @@ def datapath(request):
 
 
 @pytest.fixture(scope='session')
-def expdata(release, datapath):
+def expdata(datapath):
     ''' fixture to yield expected source data based on test data '''
     remote = data.get('remote_base')
     # remote base
-    base = remote['work'] if release == 'work' else remote['public']
+    base = remote['work'] if 'work' in datapath['release'] else remote['public']
     # sas_module; a work or DR directory
-    sas_module = datapath['work'] if release == 'work' else release.lower()
+    sas_module = datapath['work'] if 'work' in datapath['release'] else datapath['release'].lower()
     # file location
     location = datapath['location']
     # full source file location
@@ -89,9 +79,9 @@ def expdata(release, datapath):
     # full final file location
     destination = os.path.join(os.getenv('SAS_BASE_DIR'), sas_module, location)
     # combined dict
-    result = {'name': datapath['name'], 'params': datapath['params'], 'base': base, 
-              'sas_module': sas_module, 'location': location, 'source': source, 
-              'destination': destination, 'release': release.lower()}
+    result = {'name': datapath['name'], 'params': datapath['params'], 'base': base,
+              'sas_module': sas_module, 'location': location, 'source': source,
+              'destination': destination, 'release': datapath['release'].lower()}
     yield result
     result = None
 
@@ -100,9 +90,7 @@ def expdata(release, datapath):
 def inittask(expdata):
     ''' fixture to yield expected initial stream task based on test data '''
 
-    #patch = '' if expdata['release'] == 'work' else expdata['release']
-    #loc = os.path.join(patch, expdata['location'])
-    task = [{'sas_module': expdata['sas_module'], 'location': expdata['location'], 
+    task = [{'sas_module': expdata['sas_module'], 'location': expdata['location'],
              'source': expdata['source'], 'destination': expdata['destination'], 'exists': None}]
     yield task
     task = None
@@ -112,20 +100,17 @@ def inittask(expdata):
 def finaltask(expdata):
     ''' fixture to yield expected final stream task based on test data '''
 
-    task = [{'sas_module': expdata['sas_module'], 'location': expdata['location'], 
+    task = [{'sas_module': expdata['sas_module'], 'location': expdata['location'],
              'source': expdata['source'], 'destination': expdata['destination'], 'exists': None}]
     yield task
     task = None
 
 
 @pytest.fixture(scope='session')
-def rsync(release):
+def rsync(datapath):
     ''' fixture to create generic rsync object - parametrized by release '''
 
-    if 'DR' in release:
-        rsync = RsyncAccess(label='test_rsync', public=True, release=release)
-    else:
-        rsync = RsyncAccess(label='test_rsync')
+    rsync = RsyncAccess(label='test_rsync', release=datapath['release'])
     rsync.remote()
     yield rsync
     # teardown
@@ -150,23 +135,17 @@ def rstream(radd):
 
 
 @pytest.fixture(scope='session')
-def http(release):
-    if 'DR' in release:
-        http = HttpAccess(public=True, release=release)
-    else:
-        http = HttpAccess()
+def http(datapath):
+    http = HttpAccess(release=datapath['release'])
     yield http
     http = None
 
 
 @pytest.fixture(scope='session')
-def curl(release):
+def curl(datapath):
     ''' fixture to create generic curl object - parametrized by release '''
 
-    if 'DR' in release:
-        curl = CurlAccess(label='test_curl', public=True, release=release)
-    else:
-        curl = CurlAccess(label='test_curl')
+    curl = CurlAccess(label='test_curl', release=datapath['release'])
     curl.remote()
     yield curl
     # teardown

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,9 @@ import tree.tree as treemod
 from sdss_access import RsyncAccess, HttpAccess, CurlAccess
 from sdss_access.path import Path
 
+pytest_plugins = 'sphinx.testing.fixtures'
+collect_ignore = ["roots"]
+
 
 # PYTEST MODIFIERS
 # -----------------

--- a/tests/data/paths.yaml
+++ b/tests/data/paths.yaml
@@ -1,14 +1,24 @@
 
 remote_base:
-  work: rsync://sdss@dtn.sdss.org
+  work: rsync://sdss5@dtn.sdss.org
   public: rsync://dtn.sdss.org
 
 paths:
   - name: mangacube
-    work: mangawork
+    release: DR15
+    url: data.sdss.org
+    work: dr15
     params: {drpver: v2_4_3, plate: 8485, ifu: 1901, wave: LOG}
     location: manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGCUBE.fits.gz
   - name: spec-lite
-    work: ebosswork
+    release: DR15
+    url: data.sdss.org
+    work: dr15
     params: {run2d: v5_10_0, plateid: 3606, mjd: 55182, fiberid: 537}
     location: eboss/spectro/redux/v5_10_0/spectra/lite/3606/spec-3606-55182-0537.fits
+  - name: specLite
+    release: sdsswork
+    url: data.sdss5.org
+    work: sdsswork
+    params: {mjd: 59221, run2d: v6_0_9, catalogid: 4375858477, fieldid: 15013}
+    location: bhm/boss/spectro/redux/v6_0_9/spectra/lite/015013/59221/spec-015013-59221-4375858477.fits

--- a/tests/misc/test_docupaths.py
+++ b/tests/misc/test_docupaths.py
@@ -1,0 +1,32 @@
+# !usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+
+from sphinx.testing.path import path
+import pytest
+
+
+@pytest.fixture(scope="session")
+def rootdir():
+    return path(__file__).parent.parent.abspath() / "roots"
+
+
+@pytest.mark.sphinx(testroot="docupaths")
+def test_docupaths(app, status, warning):
+    app.builder.build_all()
+
+    dmdoc = app.srcdir / "_build/html/contents.html"
+    assert dmdoc.exists()
+
+    tt =  dmdoc.read_text()
+
+    # check for datamodel directive stuff
+    assert '<section id="datamodel">' in tt
+    assert '<h2>DR17<a class="headerlink" href="#dr17" title="Permalink to this heading">¶</a></h2>' in tt
+    assert "<td><p>$MANGA_SPECTRO_REDUX/{drpver}/{plate}/stack/manga-{plate}-{ifu}-{wave}CUBE.fits.gz</p></td>" in tt
+
+    # check for changelog directive stuff
+    assert '<section id="changelog">' in tt
+    assert 'Changes: DR17 from DR16' in tt
+    assert "<dt><strong>New Paths:</strong></dt><dd><ul>" in tt
+    assert '<li><p><span class="maroon">apogee_astronn</span>:  $APOGEE_ASTRONN/apogee_astroNN-{release}.fits</p></li>' in tt

--- a/tests/path/test_changelog.py
+++ b/tests/path/test_changelog.py
@@ -1,0 +1,28 @@
+# !usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+
+from sdss_access.path.changelog import compute_changelog, get_available_releases, get_path_templates
+
+
+def test_changelog():
+    cc = compute_changelog('dr17', 'dr16')
+
+    assert cc['releases'] == {'new': 'dr17', 'old': 'dr16'}
+    assert cc['paths']['new']['apogee_astronn'] == '$APOGEE_ASTRONN/apogee_astroNN-{release}.fits'
+
+
+def test_get_templates():
+    temps = get_path_templates('mangaimage')
+    assert temps['sdsswork'] is None
+    assert temps['DR17'] == '$MANGA_SPECTRO_REDUX/{drpver}/{plate}/images/{ifu}.png'
+    assert temps['DR14'] ==  '$MANGA_SPECTRO_REDUX/{drpver}/{plate}/{dir3d}/images/{ifu}.png'
+
+
+def temp_get_releases():
+    rels = get_available_releases()
+    assert 'IPL2' in rels
+    assert 'DR14' in rels
+
+    rels = get_available_releases(public=True)
+    assert 'IPL2' not in rels

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -28,8 +28,8 @@ class TestPath(object):
 
     def test_public(self):
         path = Path()
-        url = path.url('mangacube', drpver='v2_3_1', plate=8485, ifu='1901', wave='LOG')
-        assert 'mangawork' in url
+        url = path.url('specLite', mjd=61234, run2d='v6_0_9', catalogid='123456', fieldid=9876)
+        assert 'sdsswork/bhm' in url
 
         release = 'dr14'
         path = Path(public=True, release=release)
@@ -38,7 +38,7 @@ class TestPath(object):
 
     @pytest.mark.parametrize('place, exp', [('local', False), ('remote', True)])
     def test_existence(self, path, place, exp):
-        full = path.full('mangaimage', drpver='v2_5_3', plate=8116, ifu=1901, dir3d='mastar')
+        full = path.full('mangaimage', drpver='v3_1_1', plate=8116, ifu=1901, dir3d='mastar')
         exists = path.exists('', full=full, remote=(place == 'remote'), verify=False)
         assert exp == exists
 
@@ -57,9 +57,9 @@ class TestPath(object):
                               ('plateLines', '@platedir', {'plateid': 11002},
                                '0110XX/011002/plateLines-11002.png'),
                               ('spAll', '@spectrodir', {'run2d': 103},
-                               'sas/sdsswork/sdss/spectro'),
+                               'sas/dr17/sdss/spectro'),
                               ('spAll', '@spectrodir', {'run2d': 100},
-                               'sas/ebosswork/eboss/spectro')],
+                               'sas/dr17/eboss/spectro')],
                              ids=['platedir_p4', 'platedir_p5', 'spectrodir_r1', 'spectrodir_r2'])
     def test_special_function(self, path, name, special, keys, exp):
         assert special in path.templates[name]
@@ -126,22 +126,22 @@ class TestPath(object):
         name = 'mangacube'
         assert '$MANGA_SPECTRO_REDUX' in path.templates[name]
         full = path.full(name, drpver='v2_4_3', plate=8485, ifu=1901, wave='LOG')
-        exp = 'sas/mangawork/manga/spectro/redux/v2_4_3/8485'
+        exp = 'sas/dr17/manga/spectro/redux/v2_4_3/8485'
         assert exp in full
 
     @pytest.mark.parametrize('name, example, keys',
                              [('mangacube',
-                               'mangawork/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGCUBE.fits.gz',
+                               'dr17/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGCUBE.fits.gz',
                                {'drpver': 'v2_4_3', 'plate': '8485', 'ifu': '1901', 'wave': 'LOG'}),
-                              ('REJECT_MASK', 'ebosswork/eboss/lss/reject_mask/mask.html',
+                              ('REJECT_MASK', 'dr17/eboss/lss/reject_mask/mask.html',
                                {'type': 'mask', 'format': 'html'}),
-                              ('fpBIN', 'ebosswork/eboss/photo/redux/1/45/objcs/3/fpBIN-000045-g3-0123.fit',
+                              ('fpBIN', 'dr17/eboss/photo/redux/1/45/objcs/3/fpBIN-000045-g3-0123.fit',
                                {'rerun': '1', 'field': '0123', 'filter': 'g', 'camcol': '3', 'run': '000045'}),
-                              ('galaxy', 'ebosswork/eboss/lss/galaxy_DR12v1.0_1_n.fits.gz',
+                              ('galaxy', 'dr17/eboss/lss/galaxy_DR12v1.0_1_n.fits.gz',
                                {'sample': '1', 'dr': 'DR12', 'version': 'v1.0', 'ns': 'n'}),
-                              ('spec-lite', 'ebosswork/eboss/spectro/redux/v5_10_0/spectra/lite/3606/spec-3606-55182-0537.fits',
+                              ('spec-lite', 'dr17/eboss/spectro/redux/v5_10_0/spectra/lite/3606/spec-3606-55182-0537.fits',
                                {'fiberid': '0537', 'mjd': '55182', 'plateid': '3606', 'run2d': 'v5_10_0'}),
-                              ('apStar', 'apogeework/apogee/spectro/redux/r12/stars/apo25m/1234/apStar-r12-12345.fits',
+                              ('apStar', 'dr17/apogee/spectro/redux/r12/stars/apo25m/1234/apStar-r12-12345.fits',
                                {'apred': 'r12', 'apstar': 'stars', 'telescope': 'apo25m', 'field': '1234', 'prefix': 'ap', 'obj': '12345'})],
                              ids=['mangacube', 'reject', 'fpbin', 'galaxy', 'speclite', 'apstar'])
     def test_extract(self, path, name, example, keys):
@@ -161,7 +161,7 @@ class TestPath(object):
     def test_location(self, path):
         full = self.full(path)
         loc = path.location('', full=full)
-        assert 'mangawork/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-*-LOGCUBE.fits.gz' in loc
+        assert 'dr17/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-*-LOGCUBE.fits.gz' in loc
 
     def test_name(self, path):
         full = self.full(path)
@@ -171,12 +171,12 @@ class TestPath(object):
     def test_dir(self, path):
         full = self.full(path)
         d = path.dir('', full=full)
-        assert d.endswith('mangawork/manga/spectro/redux/v2_4_3/8485/stack')
+        assert d.endswith('dr17/manga/spectro/redux/v2_4_3/8485/stack')
 
     def test_url(self, path):
         full = self.full(path)
         url = path.url('', full=full)
-        assert 'https://data.sdss.org/sas/mangawork/manga/spectro/redux/' in url
+        assert 'https://data.sdss.org/sas/dr17/manga/spectro/redux/' in url
 
     @pytest.mark.parametrize('method', [('one'), ('random')])
     def test_onerandom(self, path, method):
@@ -209,7 +209,7 @@ class TestPath(object):
             assert re.search('8485-190[1-2]', item)
 
     @pytest.mark.parametrize('copydata',
-                             [('mangawork/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGCUBE.fits.gz')],
+                             [('dr17/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-1901-LOGCUBE.fits.gz')],
                              indirect=True, ids=['data'])
     def test_uncompress(self, copydata, monkeysas, path):
         ''' test to find unzipped files with zipped path templates '''
@@ -222,7 +222,7 @@ class TestPath(object):
             assert full.endswith('.fits')
 
     @pytest.mark.parametrize('copydata',
-                             [('mangawork/manga/spectro/redux/v2_5_3/8485/images/1901.png')],
+                             [('dr17/manga/spectro/redux/v2_5_3/8485/images/1901.png')],
                              indirect=True, ids=['data'])
     def test_compress(self, copydata, monkeysas, path):
         ''' test to find zipped files with non-zipped path templates '''
@@ -242,7 +242,7 @@ class TestPath(object):
         assert full.count('.gz') == 1
 
     @pytest.mark.parametrize('copymulti',
-                             [('mangawork/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-*-LOGCUBE.fits.gz')],
+                             [('dr17/manga/spectro/redux/v2_4_3/8485/stack/manga-8485-*-LOGCUBE.fits.gz')],
                              indirect=True, ids=['data'])
     @pytest.mark.parametrize('plate, ifu', [(8888, '*'), (8888, 12345),
                                             (8485, 1901), (8485, '*')],
@@ -261,8 +261,8 @@ class TestPath(object):
             assert path.netloc == 'data.mirror.sdss.org'
             assert path.remote_base == 'https://data.mirror.sdss.org'
         else:
-            assert path.netloc == 'data.sdss.org'
-            assert path.remote_base == 'https://data.sdss.org'
+            assert path.netloc == 'data.sdss5.org'
+            assert path.remote_base == 'https://data.sdss5.org'
 
     def test_path_versions(self, path):
         ff = path.full('mangaimage', plate=8485, ifu=1901, drpver='v2_4_3')
@@ -276,27 +276,22 @@ class TestPath(object):
 
     def test_svn_paths(self, path):
         ff = path.full('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007')
-        assert 'mangapreim/trunk/data' in ff
+        assert 'mangapreim/v2_9/data' in ff
         assert not ff.startswith(os.getenv("SAS_BASE_DIR"))
         assert ff.startswith(os.getenv("PRODUCT_ROOT"))
         loc = path.location('', full=ff)
         assert loc.startswith('data')
 
-    @pytest.mark.parametrize('dr', [(True), (False)])
-    def test_svn_urls(self, dr):
-        if dr:
-            path = Path(release='DR15')
-        else:
-            path = Path()
+    def test_svn_urls(self):
+        path = Path(release='DR15')
         ff = path.full('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007')
         url = path.url('', full=ff)
         assert url.startswith('https://svn.sdss.org/')
-        if dr:
-            assert 'svn.sdss.org/public' in url
+        assert 'svn.sdss.org/public' in url
 
     def test_svn_tags(self, path):
         ff = path.full('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007')
-        assert 'mangapreim/trunk/data' in ff
+        assert 'mangapreim/v2_9/data' in ff
 
         path = Path(release='DR15')
         ff = path.full('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007')

--- a/tests/path/test_sdss5.py
+++ b/tests/path/test_sdss5.py
@@ -64,6 +64,12 @@ class TestSVPaths(object):
         full = path.full(name, **keys)
         assert exp in full
 
+    @pytest.mark.parametrize('name, keys', [('specLite', ['fieldid', 'catalogid', 'run2d', 'mjd']),
+                                            ('mwmStar', ['cat_id', 'apred', 'v_astra', 'component', 'run2d']),])
+    def test_lookup_keys(self, path, name, keys):
+        realkeys = path.lookup_keys(name)
+        assert set(keys) == set(realkeys)
+
     def test_netloc(self, path):
         assert path.netloc == 'data.sdss5.org'
 

--- a/tests/path/test_sdss5.py
+++ b/tests/path/test_sdss5.py
@@ -31,7 +31,7 @@ class TestSVPaths(object):
                              [('apStar', '@healpixgrp',
                                {'apred': 'r12', 'apstar': 'stars', 'telescope': 'apo25m',
                                 'healpix': '12345', 'obj': '12345'},
-                               'r12/apo25m/12/12345/apStar-r12-apo25m-12345.fits')],
+                               'r12/stars/apo25m/12/12345/apStar-r12-apo25m-12345.fits')],
                              ids=['apStar'])
     def test_apogee_paths(self, path, name, special, keys, exp):
         assert special in path.templates[name]

--- a/tests/roots/test-docupaths/conf.py
+++ b/tests/roots/test-docupaths/conf.py
@@ -1,0 +1,2 @@
+extensions = ["sdss_access.misc.docupaths"]
+root_doc = 'contents'

--- a/tests/roots/test-docupaths/contents.rst
+++ b/tests/roots/test-docupaths/contents.rst
@@ -1,0 +1,14 @@
+datamodel
+=========
+
+.. datamodel:: sdss_access.path.path:Path
+   :prog: DR17
+   :templates:
+
+
+changelog
+=========
+
+.. changelog:: sdss_access.path.changelog:compute_changelog
+   :prog: changes
+   :drs: dr17, dr16

--- a/tests/sync/test_access.py
+++ b/tests/sync/test_access.py
@@ -41,9 +41,8 @@ def test_access(monkey_posix):
                     [('sdss5', 'data.sdss5.org'),
                      ('ipl1', 'data.sdss5.org'),
                      ('dr17', 'data.sdss.org'),
-                     ('sdsswork', 'data.sdss.org'),
-                     ('mpl9', 'data.sdss.org')],
-                    ids=['sdss5', 'ipl1', 'dr17', 'sdsswork', 'mpl9'])
+                     ('sdsswork', 'data.sdss5.org')],
+                    ids=['sdss5', 'ipl1', 'dr17', 'sdsswork'])
 def test_netloc(cfg, exp):
     a = RsyncAccess(release=cfg)
     assert a.netloc == exp
@@ -53,9 +52,8 @@ def test_netloc(cfg, exp):
                     [('sdss5', 'sdss5'),
                      ('ipl1', 'sdss5'),
                      ('dr17', ''),
-                     ('sdsswork', 'sdss'),
-                     ('mpl9', 'sdss')],
-                    ids=['sdss5', 'ipl1', 'dr17', 'sdsswork', 'mpl9'])
+                     ('sdsswork', 'sdss5')],
+                    ids=['sdss5', 'ipl1', 'dr17', 'sdsswork'])
 def test_remote_base(cfg, exp):
     a = RsyncAccess(release=cfg)
     a.remote()

--- a/tests/sync/test_auth.py
+++ b/tests/sync/test_auth.py
@@ -33,7 +33,7 @@ class TestAuth(object):
         assert auth.ready() is None
         assert auth.netrc is None
 
-    @pytest.mark.parametrize('netloc', [('data.sdss.org'), ('dtn.sdss.org')])
+    @pytest.mark.parametrize('netloc', [('data.sdss.org'), ('dtn.sdss.org'), ('data.sdss5.org')])
     def test_setnetloc(self, netloc):
         ''' test setting a url domain location '''
         auth = Auth(public=True, netloc=netloc)

--- a/tests/sync/test_curl.py
+++ b/tests/sync/test_curl.py
@@ -9,8 +9,6 @@
 # @Last Modified time: 2019-08-07 12:30:00
 
 from __future__ import print_function, division, absolute_import
-import os
-import pytest
 
 
 class TestCurl(object):
@@ -19,9 +17,6 @@ class TestCurl(object):
         name = curl.release.lower() if curl.release and 'dr' in curl.release else datapath['work']
         path = curl.url(datapath['name'], **datapath['params'])
         assert datapath['location'] in path
-        assert 'https://data.sdss.org' in path
+        assert f'https://{datapath["url"]}' in path
         assert name in path
 
-    # def test_get_locations(self, cstream, datapath):
-    #     location = cstream.get_locations()[0]
-    #     assert location == datapath['location']

--- a/tests/sync/test_http.py
+++ b/tests/sync/test_http.py
@@ -37,7 +37,7 @@ class TestHttp(object):
         name = http.release.lower() if http.release and 'dr' in http.release.lower() else datapath['work']
         path = http.url(datapath['name'], **datapath['params'])
         assert datapath['location'] in path
-        assert 'https://data.sdss.org' in path
+        assert f'https://{datapath["url"]}' in path
         assert name in path
 
     def test_svn_exist(self):
@@ -80,12 +80,12 @@ class TestHttp(object):
         assert http.auth.username is None
         assert http.auth.ready() is None
 
-    @pytest.mark.parametrize('tree_ver, exp', [('sdsswork', 'work'), ('dr15', 'dr15'),
-                                               ('dr13', 'dr13'), ('mpl8', 'work')])
-    def test_release_from_module(self, monkeypatch, tree_ver, exp, datapath):
+    @pytest.mark.parametrize('tree_ver, exp', [('dr15', 'dr15'),
+                                               ('dr13', 'dr13')])
+    def test_release_from_module(self, monkeypatch, tree_ver, exp):
         monkeypatch.setenv('TREE_VER', tree_ver)
         http = HttpAccess()
-        full = http.full(datapath['name'], **datapath['params'])
+        full = http.full('mangacube', ifu=1901, wave='LOG', plate=8485, drpver='v3_1_1')
         assert http.release == tree_ver
         assert exp in full
 

--- a/tests/sync/test_rsync.py
+++ b/tests/sync/test_rsync.py
@@ -41,17 +41,16 @@ class TestRsync(object):
         rsync.commit()
 
         path = rsync.get_paths()[0]
-        print('path', path)
         assert os.path.exists(path) is True
         assert os.path.isfile(path) is True
 
-    @pytest.mark.parametrize('tree_ver, exp', [('sdsswork', 'work'), ('dr15', 'dr15'),
-                                               ('dr13', 'dr13'), ('mpl8', 'work')])
-    def test_release_from_module(self, monkeypatch, tree_ver, exp, datapath):
+    @pytest.mark.parametrize('tree_ver, exp', [('dr15', 'dr15'),
+                                               ('dr13', 'dr13')])
+    def test_release_from_module(self, monkeypatch, tree_ver, exp):
         monkeypatch.setenv('TREE_VER', tree_ver)
         rsync = RsyncAccess()
         rsync.remote()
-        rsync.add(datapath['name'], **datapath['params'])
+        rsync.add('mangacube', ifu=1901, wave='LOG', plate=8485, drpver='v3_1_1')
         loc = rsync.initial_stream.task[0]['sas_module']
         assert rsync.release == tree_ver
         assert exp in loc
@@ -61,7 +60,7 @@ class TestRsyncFails(object):
 
     def test_access_svn_fail(self):
         with pytest.raises(AccessError) as cm:
-            access = Access()
+            access = Access(release='dr17')
             access.remote()
             access.add('mangapreimg', designid=8405, designgrp='D0084XX', mangaid='1-42007')
         assert 'Rsync/Curl Access not allowed for svn paths.  Please use HttpAccess.' in str(cm.value)


### PR DESCRIPTION
This PR updates `sdss_access` to work the version `4.0.0` of `tree`.  It bumps the major version, as it introduces breaking changes.  It also fixes the required keywords issue, closes #32.  