### PR TITLE
generalize the logic for s5cfgs

### DIFF
--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -101,7 +101,7 @@ class BasePath(object):
     _netloc = {"dtn": "dtn.sdss.org", "sdss": "data.sdss.org", "sdss5": "data.sdss5.org",
                "mirror": "data.mirror.sdss.org", "svn": "svn.sdss.org"}
     _s5cfgs = ['sdsswork', 'sdss5', 'ipl1']  # list of collab-only SDSS-V releases/configs
-
+    #_s5cfgs = ['sdss', 'ipl'] # SDSS-V releases start with sdss or ipl.
     def __init__(self, release=None, public=False, mirror=False, verbose=False,
                  force_modules=None, preserve_envvars=None):
         # set release

--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -799,6 +799,10 @@ class BasePath(object):
 
         return template
 
+    def is_sdss5(self) -> bool:
+        """ Checks if the release is an SDSS-V work or ipl release """
+        return any(s5cfg for s5cfg in self._s5cfgs if self.release.startswith(s5cfg))
+
     def get_netloc(self, netloc=None, sdss=None, sdss5=None, dtn=None, svn=None, mirror=None):
         ''' Get a net url domain
 
@@ -839,8 +843,7 @@ class BasePath(object):
         elif svn:
             return '{0}{1}'.format(self._netloc["svn"], "/public" if self.public else '')
         else:
-            sdss5 = any([s5cfg for s5cfg in self._s5cfgs if self.release.startswith(s5cfg)])
-            return self._netloc["sdss5"] if sdss5 else self._netloc["sdss"]
+            return self._netloc["sdss5"] if self.is_sdss5() else self._netloc["sdss"]
 
     def set_netloc(self, netloc=None, sdss=None, sdss5=None, dtn=None, svn=None, mirror=None):
         ''' Set a url domain location
@@ -886,8 +889,7 @@ class BasePath(object):
         if self.public or scheme == "https":
             remote_base = "{scheme}://{netloc}".format(scheme=scheme, netloc=netloc)
         else:
-            sdss5 = any([s5cfg for s5cfg in self._s5cfgs if self.release.startswith(s5cfg)])
-            user = "sdss5" if sdss5 else "sdss"
+            user = "sdss5" if self.is_sdss5() else "sdss"
             remote_base = "{scheme}://{user}@{netloc}".format(scheme=scheme, user=user, netloc=netloc)
         return remote_base
 

--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -100,7 +100,6 @@ class BasePath(object):
 
     _netloc = {"dtn": "dtn.sdss.org", "sdss": "data.sdss.org", "sdss5": "data.sdss5.org",
                "mirror": "data.mirror.sdss.org", "svn": "svn.sdss.org"}
-    #_s5cfgs = ['sdsswork', 'sdss5', 'ipl1']  # list of collab-only SDSS-V releases/configs
     _s5cfgs = ['sdss', 'ipl'] # SDSS-V releases start with sdss or ipl.
 
     def __init__(self, release=None, public=False, mirror=False, verbose=False,

--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -839,7 +839,8 @@ class BasePath(object):
         elif svn:
             return '{0}{1}'.format(self._netloc["svn"], "/public" if self.public else '')
         else:
-            return self._netloc["sdss5"] if self.release in self._s5cfgs else self._netloc["sdss"]
+            sdss5 = any([s5cfg for s5cfg in self._s5cfgs if self.release.startswith(s5cfg)])
+            return self._netloc["sdss5"] if sdss5 else self._netloc["sdss"]
 
     def set_netloc(self, netloc=None, sdss=None, sdss5=None, dtn=None, svn=None, mirror=None):
         ''' Set a url domain location
@@ -885,7 +886,8 @@ class BasePath(object):
         if self.public or scheme == "https":
             remote_base = "{scheme}://{netloc}".format(scheme=scheme, netloc=netloc)
         else:
-            user = "sdss5" if self.release in self._s5cfgs else "sdss"
+            sdss5 = any([s5cfg for s5cfg in self._s5cfgs if self.release.startswith(s5cfg)])
+            user = "sdss5" if sdss5 else "sdss"
             remote_base = "{scheme}://{user}@{netloc}".format(scheme=scheme, user=user, netloc=netloc)
         return remote_base
 

--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -100,8 +100,9 @@ class BasePath(object):
 
     _netloc = {"dtn": "dtn.sdss.org", "sdss": "data.sdss.org", "sdss5": "data.sdss5.org",
                "mirror": "data.mirror.sdss.org", "svn": "svn.sdss.org"}
-    _s5cfgs = ['sdsswork', 'sdss5', 'ipl1']  # list of collab-only SDSS-V releases/configs
-    #_s5cfgs = ['sdss', 'ipl'] # SDSS-V releases start with sdss or ipl.
+    #_s5cfgs = ['sdsswork', 'sdss5', 'ipl1']  # list of collab-only SDSS-V releases/configs
+    _s5cfgs = ['sdss', 'ipl'] # SDSS-V releases start with sdss or ipl.
+
     def __init__(self, release=None, public=False, mirror=False, verbose=False,
                  force_modules=None, preserve_envvars=None):
         # set release

--- a/python/sdss_access/sync/baseaccess.py
+++ b/python/sdss_access/sync/baseaccess.py
@@ -35,8 +35,9 @@ class BaseAccess(six.with_metaclass(abc.ABCMeta, AuthMixin, Path)):
         use_dtn = self.remote_scheme == 'rsync'
         # simplifies things to have a single sdss (or sdss5) machine in
         # .netrc for SDSS-IV  (or SDSS-V, respectively).
-        #sdss5 = ( self.release in self._s5cfgs )
         sdss5 = any([s5cfg for s5cfg in self._s5cfgs if self.release.startswith(s5cfg)])
+        # set sdss5 true if s5cfg (e.g. sdsswork or ipl-N) starts with
+        # values defined in self._s5cfgs (e.g. sdss or ipl).
         self.set_netloc(sdss=not sdss5, sdss5=sdss5)
         self.set_auth(username=username, password=password, inquire=inquire)
         if use_dtn:

--- a/python/sdss_access/sync/baseaccess.py
+++ b/python/sdss_access/sync/baseaccess.py
@@ -35,7 +35,7 @@ class BaseAccess(six.with_metaclass(abc.ABCMeta, AuthMixin, Path)):
         use_dtn = self.remote_scheme == 'rsync'
         # simplifies things to have a single sdss (or sdss5) machine in
         # .netrc for SDSS-IV  (or SDSS-V, respectively).
-        sdss5 = any([s5cfg for s5cfg in self._s5cfgs if self.release.startswith(s5cfg)])
+        sdss5 = self.is_sdss5()
         # set sdss5 true if s5cfg (e.g. sdsswork or ipl-N) starts with
         # values defined in self._s5cfgs (e.g. sdss or ipl).
         self.set_netloc(sdss=not sdss5, sdss5=sdss5)

--- a/python/sdss_access/sync/baseaccess.py
+++ b/python/sdss_access/sync/baseaccess.py
@@ -35,7 +35,8 @@ class BaseAccess(six.with_metaclass(abc.ABCMeta, AuthMixin, Path)):
         use_dtn = self.remote_scheme == 'rsync'
         # simplifies things to have a single sdss (or sdss5) machine in
         # .netrc for SDSS-IV  (or SDSS-V, respectively).
-        sdss5 = ( self.release in self._s5cfgs )
+        #sdss5 = ( self.release in self._s5cfgs )
+        sdss5 = any([s5cfg for s5cfg in self._s5cfgs if self.release.startswith(s5cfg)])
         self.set_netloc(sdss=not sdss5, sdss5=sdss5)
         self.set_auth(username=username, password=password, inquire=inquire)
         if use_dtn:


### PR DESCRIPTION
generalized the logic for s5cfgs to include the sequence of all ipls to prevent new ipls from being broken or at least fragile.  @havok2063 feel free to edit as you like.