### PR TITLE
Add support for fz compression

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ Change Log
 
 This document records the main changes to the sdss_access code.
 
+3.0.2 (unreleased)
+------------------
+- Add support for .fz compression
+
 3.0.1 (2023-06-17)
 ------------------
 - Bug fix for remote access to IPLs > IPL-1

--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -100,7 +100,7 @@ class BasePath(object):
 
     _netloc = {"dtn": "dtn.sdss.org", "sdss": "data.sdss.org", "sdss5": "data.sdss5.org",
                "mirror": "data.mirror.sdss.org", "svn": "svn.sdss.org"}
-    _s5cfgs = ['sdss', 'ipl'] # SDSS-V releases start with sdss or ipl.
+    _s5cfgs = ['sdss', 'ipl']  # SDSS-V releases start with sdss or ipl.
 
     def __init__(self, release=None, public=False, mirror=False, verbose=False,
                  force_modules=None, preserve_envvars=None):
@@ -112,7 +112,7 @@ class BasePath(object):
 
         # set attributes
         self._special_fxn_pattern = r"\@\w+[|]"
-        self._compressions = ['.gz', '.bz2', '.zip']
+        self._compressions = ['.gz', '.bz2', '.zip', '.fz']
         self._comp_regex = r'({0})$'.format('|'.join(self._compressions))
 
         # set the path templates from the tree

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ dev =
 	wheel>=0.33.6
 
 docs =
-	Sphinx>=2.1.0
+	Sphinx>=7.1.0
 	sphinx_bootstrap_theme>=0.4.12
 	recommonmark>=0.6
 	sphinx-issues>=1.2.0

--- a/tests/misc/test_docupaths.py
+++ b/tests/misc/test_docupaths.py
@@ -18,11 +18,11 @@ def test_docupaths(app, status, warning):
     dmdoc = app.srcdir / "_build/html/contents.html"
     assert dmdoc.exists()
 
-    tt =  dmdoc.read_text()
+    tt = dmdoc.read_text()
 
     # check for datamodel directive stuff
     assert '<section id="datamodel">' in tt
-    assert '<h2>DR17<a class="headerlink" href="#dr17" title="Permalink to this heading">¶</a></h2>' in tt
+    assert '<h2>DR17<a class="headerlink" href="#dr17" title="Link to this heading">¶</a></h2>' in tt
     assert "<td><p>$MANGA_SPECTRO_REDUX/{drpver}/{plate}/stack/manga-{plate}-{ifu}-{wave}CUBE.fits.gz</p></td>" in tt
 
     # check for changelog directive stuff

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -340,6 +340,26 @@ class TestPath(object):
 
         assert f1 == f2
 
+    @pytest.mark.parametrize('exist', [True, False])
+    def test_fzcomp(self, exist, path, monkeypatch, tmp_path):
+        """ test to test we recognize fz files """
+
+        d = tmp_path / "sas"
+        d.mkdir()
+
+        # create the file
+        if exist:
+            ff = d / "test.txt"
+            ff.touch()
+
+        monkeypatch.setitem(path.templates, 'test', str(d/'test.txt.fz'))
+        pp = path.full('test')
+        print(pp)
+
+        if exist:
+            assert pp.endswith('test.txt')
+        else:
+            assert pp.endswith('test.txt.fz')
 
 @pytest.fixture()
 def monkeyoos(monkeypatch, mocker):


### PR DESCRIPTION
This PR fixes #43 and adds support for Path to understand files with `.fz` compression.  