### PR TITLE
Adds new tilegrp method for LVM

### DIFF
--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -1275,7 +1275,7 @@ class Path(BasePath):
         -------
         sdssid_groups : str
             A set of folders.
-        '''        
+        '''
         # with k = 100 then even with 10 M sources, each folder will have ~1,000 files
         k = 100
         sdss_id = int(kwargs["sdss_id"])
@@ -1480,6 +1480,29 @@ class Path(BasePath):
         else:
             return fieldid
 
+    def tilegrp(self, filetype, **kwargs):
+        ''' Returns LVM tile id group subdirectory
+
+        Parameters
+        ----------
+        filetype : str
+            File type parameter.
+        tileid : int or str
+            LVM Tile ID number.  Will be converted to int internally.
+
+        Returns
+        -------
+        tileidgrp : str
+            Tile ID group directory in the format ``NNNNXX``.
+
+        '''
+
+        tileid = kwargs.get('tileid', None)
+        if not tileid:
+            return '0000XX'
+        elif '*' in str(tileid):
+            return '{0}XX'.format(tileid)
+        return '{:0>4d}XX'.format(int(tileid) // 1000)
 
 class AccessError(Exception):
     pass

--- a/tests/path/test_sdss5.py
+++ b/tests/path/test_sdss5.py
@@ -58,9 +58,13 @@ class TestSVPaths(object):
                               ('spFrame', '@pad_fieldid', {'run2d': 'v6_0_4', 'br': 'b', 'id': '1', 'frame': '5432', 'fieldid':'1234'},
                                 'v6_0_4/1234p/spFrame-b1-00005432.fits.gz'),
                               ('spField', '@pad_fieldid', {'run2d': 'v6_1_1', 'mjd': '59630', 'fieldid': '*'},
-                                'v6_1_1/*/spField-*-59630.fits')],
+                                'v6_1_1/*/spField-*-59630.fits'),
+                              ('lvm_frame', '@tilegrp', {'drpver': 'master', 'mjd': 60235,
+                                                         'tileid': 1055360, 'kind': 'CFrame', 'expnum': 6817},
+                               '1055XX/1055360/60235/lvmCFrame-00006817.fits')],
                              ids=['configgrp', 'apgprefix-apo', 'apgprefix-lco', 'apgprefix-ins',
-                                  'isplate-v6_0_4','pad_fieldid-5','pad_fieldid-6', 'frame-pad', 'frame-nopadp', 'pad_fieldid-*'])
+                                  'isplate-v6_0_4','pad_fieldid-5','pad_fieldid-6', 'frame-pad', 'frame-nopadp',
+                                  'pad_fieldid-*', 'lvm-tileid'])
     def test_special_function(self, path, name, special, keys, exp):
         assert special in path.templates[name]
         full = path.full(name, **keys)


### PR DESCRIPTION
This PR adds a new `tilegrp` method to produce a tile id integer grouping for the LVM DRP outputs.  This will make the SAS structure more navigable. 