### PR TITLE
Updates test action to use main tree repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,30 @@ name: Build and Test
 on: [push, pull_request]
 
 jobs:
-  build:
+  tree:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone tree
+      uses: actions/checkout@v4
+      with:
+        repository: sdss/tree
+        path: tree
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+    - name: Install tree package
+      run: |
+        python -m pip install --upgrade pip
+        cd tree
+        pip install .
 
+  build:
+    needs: tree
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,38 +6,36 @@ name: Build and Test
 on: [push, pull_request]
 
 jobs:
-  tree:
+  build:
     runs-on: ubuntu-latest
+
     steps:
+    - name: Clone sdss_access
+      uses: actions/checkout@v4
+
     - name: Clone tree
       uses: actions/checkout@v4
       with:
         repository: sdss/tree
         path: tree
+
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
         python-version: 3.9
+
     - name: Install tree package
       run: |
         python -m pip install --upgrade pip
         cd tree
         pip install .
+        cd $GITHUB_WORKSPACE
 
-  build:
-    needs: tree
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-    - name: Install dependencies
+    - name: Install access dependencies
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
+
     - name: Lint with flake8
       run: |
         pip install flake8
@@ -45,12 +43,14 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
     - name: Setup SDSS-IV netrc
       uses: extractions/netrc@v1
       with:
         machine: data.sdss.org
         username: ${{ secrets.S4_USERNAME }}
         password: ${{ secrets.S4_PASSWORD }}
+
     - name: Setup SDSS-V netrc
       uses: extractions/netrc@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Clone sdss_access
       uses: actions/checkout@v4
+      with:
+        path: access
 
     - name: Clone tree
       uses: actions/checkout@v4
@@ -34,6 +36,7 @@ jobs:
     - name: Install access dependencies
       run: |
         python -m pip install --upgrade pip
+        cd access
         pip install .[dev]
 
     - name: Lint with flake8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Clone sdss_access
+    - name: Clone access
       uses: actions/checkout@v4
       with:
         path: access

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,10 +63,11 @@ jobs:
 
     - name: Test with pytest
       run: |
+        cd access
         pip install pytest
         pytest
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
-        file: ./coverage.xml
+        file: ./access/coverage.xml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ This document records the main changes to the sdss_access code.
 
 3.0.3 (unreleased)
 ------------------
+- Add new ``tilegrp`` method for grouping LVM tile ids
+- Updates test action to use the latest tree git repo
 
 3.0.2 (11-2-2023)
 ------------------


### PR DESCRIPTION
This PR closes #33. It updates the test Github Action to use the latest `main` repo of `tree`, rather than the latest PyPi tag.  This allows `sdss_access` to have the latest paths in tree, and pass any new tests, before a tag has been pushed to PyPi.