### PR TITLE
bug fix for rsync on remote compressed file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ Change Log
 
 This document records the main changes to the sdss_access code.
 
+3.0.4 (unreleased)
+------------------
+- Fix issue `52` - rsync failure when remote file is compressed compared to template
+
 3.0.3 (11-29-2023)
 ------------------
 - Add new ``tilegrp`` method for grouping LVM tile ids

--- a/python/sdss_access/sync/rsync.py
+++ b/python/sdss_access/sync/rsync.py
@@ -13,9 +13,9 @@ class RsyncAccess(BaseAccess):
     remote_scheme = 'rsync'
     access_mode = 'rsync'
 
-    def __init__(self, label='sdss_rsync', stream_count=5, mirror=False, public=False, release=None, 
+    def __init__(self, label='sdss_rsync', stream_count=5, mirror=False, public=False, release=None,
                  verbose=False):
-        super(RsyncAccess, self).__init__(stream_count=stream_count, mirror=mirror, public=public, 
+        super(RsyncAccess, self).__init__(stream_count=stream_count, mirror=mirror, public=public,
                                           release=release, verbose=verbose)
         self.label = label
         self.auth = None
@@ -29,7 +29,7 @@ class RsyncAccess(BaseAccess):
 
     def get_task_out(self, task=None):
         if task:
-            command = "rsync -R %(source)s" % task
+            command = "rsync -R %(source)s*" % task
             if self.verbose:
                 print(command)
             status, out, err = self.stream.cli.foreground_run(command)

--- a/tests/sync/test_rsync.py
+++ b/tests/sync/test_rsync.py
@@ -67,7 +67,7 @@ class TestRsync(object):
         # remote source is fully resolved path
         rsync.add("mwmAllStar", v_astra="0.5.0")
         rsync.set_stream()
-        source = rsync.initial_stream.task[0]['source']
+        source = rsync.stream.task[0]['source']
         assert source.endswith('0.5.0/summary/mwmAllStar-0.5.0.fits.gz')
 
 

--- a/tests/sync/test_rsync.py
+++ b/tests/sync/test_rsync.py
@@ -55,6 +55,22 @@ class TestRsync(object):
         assert rsync.release == tree_ver
         assert exp in loc
 
+    def test_remote_compression(self):
+        """ test we can find the correct file when the remote file is compressed """
+        rsync = RsyncAccess(release='ipl3')
+        rsync.remote()
+
+        # template path is not compressed
+        ff = rsync.templates["mwmAllStar"]
+        assert ff.endswith('summary/mwmAllStar-{v_astra}.fits')
+
+        # remote source is fully resolved path
+        rsync.add("mwmAllStar", v_astra="0.5.0")
+        rsync.set_stream()
+        source = rsync.initial_stream.task[0]['source']
+        assert source.endswith('0.5.0/summary/mwmAllStar-0.5.0.fits.gz')
+
+
 
 class TestRsyncFails(object):
 


### PR DESCRIPTION
Closes #52.  This PR fixes a bug when trying to rsync a file that is compressed on disk, but the template path is not compressed.   It adds a wildcard to the end of the initial stream task rsync `source` to ensure it can find compressed files remotely.

```
from sdss_access import Access

access = Access(release="ipl3")
access.remote()

access.add("mwmAllStar", v_astra="0.5.0")
access.set_stream()

access.stream.task

[{'sas_module': 'ipl-3',
  'location': 'spectro/astra/0.5.0/summary/mwmAllStar-0.5.0.fits.gz',
  'source': 'rsync://sdss5@dtn.sdss.org/ipl-3/spectro/astra/0.5.0/summary/mwmAllStar-0.5.0.fits.gz',
  'destination': '/Users/Brian/Work/sdss/sas/ipl-3/spectro/astra/0.5.0/summary/mwmAllStar-0.5.0.fits.gz',
  'exists': None}]
```