### PR TITLE
Adds option for adding a temporary path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ This document records the main changes to the sdss_access code.
 3.0.4 (unreleased)
 ------------------
 - Fix issue `52` - rsync failure when remote file is compressed compared to template
+- Issue `48` - Add support for adding temporary paths for use in local sdss_access
 
 3.0.3 (11-29-2023)
 ------------------

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -361,6 +361,28 @@ class TestPath(object):
         else:
             assert pp.endswith('test.txt.fz')
 
+    @pytest.mark.parametrize('name, temp, envvar, exp',
+                             [('testFile', '$LVM_DATA_S/test_file_{ver}.fits', None, 'sdsswork/data/lvm/lco'),
+                              ('testFile', '$TEST_DIR/test_file_{ver}.fits', '/tmp/test/path/', 'tmp/test/path')],
+                             ids=['withev', 'newev'])
+    def test_add_temp_path(self, path, name, temp, envvar, exp):
+        path.add_temp_path(name, temp, envvar_path=envvar)
+
+        full = path.full(name, ver='1.0')
+        assert full.endswith('test_file_1.0.fits')
+        assert exp in full
+
+
+    @pytest.mark.parametrize('name, temp, msg',
+                        [("testFile!", "/path/to/testfile.fits", 'Name can only consist of letters, numbers, dashes'),
+                         ("testFile", "/path/to/testfile.fits", 'Template path must start with an environment variable'),
+                         ("testFile", "$TEST_DI/testfile.fits", 'Template path envvar not defined in local environment')],
+                        ids=['badname', 'badpath', 'noenvvar'])
+    def test_add_temp_fails(self, path, name, temp, msg):
+        with pytest.raises(ValueError, match=msg):
+            path.add_temp_path(name, temp)
+
+
 @pytest.fixture()
 def monkeyoos(monkeypatch, mocker):
     ''' monkeypatch the original os environ from tree '''


### PR DESCRIPTION
Closes #48.  This PR adds a new method to the Path, `add_temp_path`, which allows the addition of new temporary path templates into the local Python environment for use in `sdss_access`.  This can be useful when developing new paths in code, when using `sdss_acces` and a tagged version of `tree`.  This lets you add the paths in the interim until they can get properly added into the `tree` product and a new tag made.  They are not persistent and only work for local path stuff only.

You specify a template `name` and `path`.  The `path` must start with an environment variable and if it doesn't exist in the local environment already, you can define it with the `envvar_path` keyword. 

```
from sdss_access import Access

access = Access()
access.add_temp_path("newCalib", "$LVM_SPECTRO_REDUX/{drpver}/@tilegrp|/{tileid}/new_calib.fits")
access.full("newCalib", drpver="1.0.0", tileid="1234567")
'/Users/Brian/Work/sdss/sas/sdsswork/lvm/spectro/redux/1.0.0/1234XX/1234567/new_calib.fits'

# add with a temporary envvar
access.add_temp_path('testFile', '$TEST_DIR/test_file_{ver}.fits', envvar_path='/tmp/test/dir')
access.full('testFile', ver='1.0')
'/tmp/test/dir/test_file_1.0.fits'
``` 