### PR TITLE
Adds option for adding a resolved url or filepath for stream downloading

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ This document records the main changes to the sdss_access code.
 ------------------
 - Fix issue `52` - rsync failure when remote file is compressed compared to template
 - Issue `48` - Add support for adding temporary paths for use in local sdss_access
+- Issue `55` - Add support for adding resolved urls or filepaths into sdss_access remote download
 
 3.0.3 (11-29-2023)
 ------------------

--- a/docs/sphinx/intro.rst
+++ b/docs/sphinx/intro.rst
@@ -285,6 +285,29 @@ In all all cases, successful ``sdss_access`` downloads will return a code of 0. 
 occurred.  If no verbose message is displayed, you may need to check the ``sdss_access_XX.log`` and ``sdss_access_XX.err``
 files within the temporary directory.
 
+Downloading with Resolved Paths
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you already have a list of resolved filepaths or urls that you wish to use ``sdss_access``
+to download, you can add them using the ``.add_file`` method, instead of the ``.add`` method.
+The ``.add`` method takes as input a ``path_name`` and set of path template keyword
+arguments, while ``.add_file`` takes either a fully resolved url, filepath, or location.
+The ``input_type`` keyword specifies the type of path input.
+::
+
+    from sdss_access import RsyncAccess
+    rsync = RsyncAccess(release='DR17')
+    rsync.remote()
+
+    # add a url to the stream for download
+    url = 'rsync://dtn.sdss.org/dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
+    rsync.add_file(f, input_type='url')
+
+    # add a file to the stream for download
+    path = '/Users/Brian/Work/sdss/sas/dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1902-LOGCUBE.fits.gz'
+    rsync.add_file(path, input_type='filepath')
+
+
 Accessing SDSS-V Products
 -------------------------
 

--- a/python/sdss_access/sync/baseaccess.py
+++ b/python/sdss_access/sync/baseaccess.py
@@ -103,16 +103,16 @@ class BaseAccess(six.with_metaclass(abc.ABCMeta, AuthMixin, Path)):
         # determine stream task info
         if input_type == 'filepath':
             location = self.location('', full=path)
-            sas_module, location = location.split(sep, 1)
+            sas_module, location = location.split(sep, 1) if location else (None, location)
             source = self.url('', sasdir=sasdir, full=path)
             dest = path
         elif input_type == 'url':
             dest = path.replace(f'{self.remote_base}/{sasdir}', self.base_dir)
             source = path
             location = self.location('', full=dest)
-            sas_module, location = location.split(sep, 1)
+            sas_module, location = location.split(sep, 1) if location else (None, location)
         elif input_type == 'location':
-            sas_module, location = path.split(sep, 1)
+            sas_module, location = path.split(sep, 1) if path else (None, path)
             dest = join(self.base_dir, path)
             source = self.url('', sasdir=sasdir, full=dest)
 

--- a/python/sdss_access/sync/baseaccess.py
+++ b/python/sdss_access/sync/baseaccess.py
@@ -69,6 +69,57 @@ class BaseAccess(six.with_metaclass(abc.ABCMeta, AuthMixin, Path)):
         else:
             print("There is no file with filetype=%r to access in the tree module loaded" % filetype)
 
+    def add_file(self, path, input_type = None):
+        """ Adds a file into the list of tasks to download
+
+        Adds a full filepath, url, or location to the list of tasks to
+        download.  This takes advantage of ``sdss_access`` parallel streams
+        to download a list of files.
+
+        This is similar to the  ``.add`` method, except this takes
+        full filepaths or urls as input, whereas the ``.add`` method
+        is better when inputing a product name and path template kwargs.
+
+        Parameters
+        ----------
+        path : str
+            the filepath, url, or location
+        input_type : str, optional
+            the type of input, by default None
+        """
+
+        # check for input_type if none provided
+        if not input_type:
+            if path.startswith(('rsync', 'http')):
+                input_type = 'url'
+            elif path.startswith('/'):
+                input_type = 'filepath'
+            else:
+                input_type = 'location'
+
+        # use the right sasdir based on mode
+        sasdir = 'sas' if self.access_mode == 'curl' else ''
+
+        # determine stream task info
+        if input_type == 'filepath':
+            location = self.location('', full=path)
+            sas_module, location = location.split(sep, 1)
+            source = self.url('', sasdir=sasdir, full=path)
+            dest = path
+        elif input_type == 'url':
+            dest = path.replace(f'{self.remote_base}/{sasdir}', self.base_dir)
+            source = path
+            location = self.location('', full=dest)
+            sas_module, location = location.split(sep, 1)
+        elif input_type == 'location':
+            sas_module, location = path.split(sep, 1)
+            dest = join(self.base_dir, path)
+            source = self.url('', sasdir=sasdir, full=dest)
+
+        # append the task to the stream
+        self.initial_stream.append_task(sas_module=sas_module, location=location,
+                                        source=source, destination=dest)
+
     def set_stream(self):
         """ Sets the download streams """
 

--- a/python/sdss_access/sync/baseaccess.py
+++ b/python/sdss_access/sync/baseaccess.py
@@ -107,6 +107,7 @@ class BaseAccess(six.with_metaclass(abc.ABCMeta, AuthMixin, Path)):
             source = self.url('', sasdir=sasdir, full=path)
             dest = path
         elif input_type == 'url':
+            self.set_base_dir()
             dest = path.replace(f'{self.remote_base}/{sasdir}', self.base_dir)
             source = path
             location = self.location('', full=dest)

--- a/tests/sync/test_curl.py
+++ b/tests/sync/test_curl.py
@@ -9,7 +9,7 @@
 # @Last Modified time: 2019-08-07 12:30:00
 
 from __future__ import print_function, division, absolute_import
-
+import pytest
 
 class TestCurl(object):
 
@@ -20,3 +20,25 @@ class TestCurl(object):
         assert f'https://{datapath["url"]}' in path
         assert name in path
 
+    @pytest.mark.parametrize('input_type', ['filepath', 'url', 'location'])
+    def test_add_files(self, curl, expdata, input_type):
+
+        # hack the source for curl
+        source = (expdata['source'].replace('rsync://sdss5@dtn.sdss.org/',
+                                           'https://data.sdss5.org/sas/')
+                  .replace('rsync://dtn.sdss.org/', 'https://data.sdss.org/sas/'))
+
+        if input_type == 'filepath':
+            path = expdata.get('destination')
+        elif input_type == 'url':
+            path = source
+        else:
+            path = expdata.get('location')
+
+        expout = {'sas_module': expdata['sas_module'], 'location': expdata['location'],
+                  'source': source, 'destination': expdata['destination'],
+                  'exists': None}
+
+        curl.add_file(path, input_type=input_type)
+        task = curl.initial_stream.task[0]
+        assert task == expout

--- a/tests/sync/test_rsync.py
+++ b/tests/sync/test_rsync.py
@@ -98,10 +98,10 @@ class TestRsyncFails(object):
 class TestStream(object):
     def test_initial_stream(self, radd, inittask):
         task = radd.initial_stream.task
-        assert task == inittask
+        assert task[0] == inittask[0]
 
     def test_final_stream(self, rstream, finaltask):
         task = rstream.stream.task
-        assert task == finaltask
+        assert task[0] == finaltask[0]
 
 

--- a/tests/sync/test_rsync.py
+++ b/tests/sync/test_rsync.py
@@ -70,6 +70,19 @@ class TestRsync(object):
         source = rsync.stream.task[0]['source']
         assert source.endswith('0.5.0/summary/mwmAllStar-0.5.0.fits.gz')
 
+    @pytest.mark.parametrize('input_type', ['filepath', 'url', 'location'])
+    def test_add_files(self, rsync, expdata, inittask, input_type):
+
+        if input_type == 'filepath':
+            path = expdata.get('destination')
+        elif input_type == 'url':
+            path = expdata.get('source')
+        else:
+            path = expdata.get('location')
+
+        rsync.add_file(path, input_type=input_type)
+        task = rsync.initial_stream.task[0]
+        assert task == inittask[0]
 
 
 class TestRsyncFails(object):
@@ -90,3 +103,5 @@ class TestStream(object):
     def test_final_stream(self, rstream, finaltask):
         task = rstream.stream.task
         assert task == finaltask
+
+


### PR DESCRIPTION
This PR closes #55 and adds the option using sdss_access stream downloading if you already have fully resolved urls or filepaths instead of a set of path keyword arguments.  It adds a new method `.add_file` that accepts either a filepath, url, or path location and reconstructs the correct input to stream.  

```
access = Access(release='DR17')
access.remote()
f = '/Users/Brian/Work/sdss/sas/dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
access.add_file(f, input_type='filepath')
access.set_stream()
access.commit()
```
or a resolved url
```
access = Access(release='DR17')
access.remote()
u = 'rsync://dtn.sdss.org/dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1901-LOGCUBE.fits.gz'
access.add_file(u, input_type='url')
access.set_stream()
access.commit()
```