### PR TITLE
updating the pypi workflow release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
 
         runs-on: ubuntu-latest
 
+        permissions:
+          content: write
+          id-token: write
+
         steps:
 
             - name: Checkout code
@@ -43,7 +47,4 @@ jobs:
                 python setup.py sdist bdist_wheel --universal
 
             - name: Publish to PyPI
-              uses: pypa/gh-action-pypi-publish@master
-              with:
-                  user: __token__
-                  password: ${{ secrets.pypi_password }}
+              uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR update the github action workflow for publishing to PyPI, following https://docs.pypi.org/trusted-publishers/adding-a-publisher/ and https://docs.pypi.org/trusted-publishers/using-a-publisher/. 
