### PR TITLE
Fixes rsync for mac sequoia

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ This document records the main changes to the sdss_access code.
 3.0.5 (unreleased)
 ------------------
 - PR `62` - Fix issue `61`: removed use of ``disutils`` which has been Deprecated in Python 3.12. Also pin Sphinx to ``<7.3.0`` to address `this issue <https://github.com/sphinx-doc/sphinx/issues/12339>`.
+- Adding `-i` to rsync stream command to accommodate issues with new Mac OS Sequoia
 
 3.0.4 (03-08-2024)
 ------------------

--- a/python/sdss_access/sync/rsync.py
+++ b/python/sdss_access/sync/rsync.py
@@ -29,7 +29,7 @@ class RsyncAccess(BaseAccess):
 
     def get_task_out(self, task=None):
         if task:
-            command = "rsync -R %(source)s*" % task
+            command = "rsync -Ri %(source)s*" % task
             if self.verbose:
                 print(command)
             status, out, err = self.stream.cli.foreground_run(command)


### PR DESCRIPTION
This PR closes #70.  It adds the `-i`, or `--itemize-changes` option to the rsync command to fix downloads on Mac OS Sequoia.  