### PR TITLE
Fixes the broken github action

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.7dev
+current_version = 3.0.7
 commit = True
 tag = False
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.7
+current_version = 3.0.8dev
 commit = True
 tag = False
 tag_name = {new_version}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         path: tree
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         steps:
 
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v4
 
             - name: Create Release
               id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         steps:
 
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v5
 
             - name: Create Release
               id: create_release
@@ -31,9 +31,9 @@ jobs:
                   prerelease: false
 
             - name: Set up Python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
-                  python-version: 3.7
+                  python-version: "3.11"
 
             - name: Install dependencies
               run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,12 @@ Change Log
 
 This document records the main changes to the sdss_access code.
 
-3.0.7 (unreleased)
+3.0.8 (unreleased)
 ------------------
+
+3.0.7 (04-16-2025)
+------------------
+- Fix to outdated github actions
 
 3.0.6 (04-16-2025)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-access
-version = 3.0.7dev
+version = 3.0.7
 author = Brian Cherinka
 author_email = bcherinka@stsci.edu
 description = Package to dynamically build filepaths and access all SDSS SAS products

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-access
-version = 3.0.7
+version = 3.0.8dev
 author = Brian Cherinka
 author_email = bcherinka@stsci.edu
 description = Package to dynamically build filepaths and access all SDSS SAS products


### PR DESCRIPTION
The release Github Action was broken as it was using an outdated Python, which has now been removed. 