### PR TITLE
adding simple pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -11,3 +11,6 @@ python:
         path: .
         extra_requirements:
             - docs
+
+sphinx:
+  configuration: docs/sphinx/conf.py


### PR DESCRIPTION
This PR adds a simple pyproject.toml for pep-517 and updates the readthedocs config so it can build again.  