### PR TITLE
Support wildcard `'*'` for num in MOS target paths

### DIFF
--- a/python/sdss_access/path/path.py
+++ b/python/sdss_access/path/path.py
@@ -1825,8 +1825,13 @@ class Path(BasePath):
             raise ValueError("Invalid ftype. Must be 'fits' or 'parquet'.")
         elif ftype == "fits":
             num = kwargs.get("num", None)
+            
             if num is None:
                 raise ValueError("Missing required keyword argument 'num'.")
+            
+            if str(num) == "*":
+                return f"{prefix}*"
+            
             num = int(num)
             if num > 0:
                 num_zp = f"{num:0>{zp}}" if zp is not None else str(num)

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -59,19 +59,11 @@ class TestPath(object):
                               ('spAll', '@spectrodir', {'run2d': 103},
                                'sas/dr17/sdss/spectro'),
                               ('spAll', '@spectrodir', {'run2d': 100},
-                               'sas/dr17/eboss/spectro'),
-                              ('mos_target_sdss_id_flat', '@mos_target_num3',
-                               {'v_targ': '2.0.0', 'ftype': 'fits', 'num': 10},
-                               'sas/dr20/mos/target/2.0.0/fits/mos_sdss_id_flat-010.fits')],
-                             ids=['platedir_p4', 'platedir_p5', 'spectrodir_r1', 'spectrodir_r2', 'mos_target_num3'])
+                               'sas/dr17/eboss/spectro')],
+                             ids=['platedir_p4', 'platedir_p5', 'spectrodir_r1', 'spectrodir_r2'])
     def test_special_function(self, path, name, special, keys, exp):
-        if name == 'mos_target_sdss_id_flat':
-            pp = Path(release='dr20')
-        else:
-            pp = path
-
-        assert special in pp.templates[name]
-        full = pp.full(name, **keys)
+        assert special in path.templates[name]
+        full = path.full(name, **keys)
         assert exp in full
 
     @pytest.mark.parametrize('key, val, exp',

--- a/tests/path/test_sdss5.py
+++ b/tests/path/test_sdss5.py
@@ -20,7 +20,7 @@ from sdss_access import config
 
 @pytest.fixture(scope='module')
 def path():
-    pp = Path(release='sdss5')
+    pp = Path(release='dr20')
     yield pp
     pp = None
 
@@ -73,11 +73,16 @@ class TestSVPaths(object):
                                 'v6_2_0/summary/allepoch/spAll-v6_2_0-allepoch.fits'),
                               ('lvm_frame', '@tilegrp', {'drpver': 'master', 'mjd': 60235,
                                                          'tileid': 1055360, 'kind': 'CFrame', 'expnum': 6817},
-                               '1055XX/1055360/60235/lvmCFrame-00006817.fits')],
+                               '1055XX/1055360/60235/lvmCFrame-00006817.fits'),
+                              ('mos_target_sdss_id_flat', '@mos_target_num3',
+                               {'v_targ': '2.0.0', 'ftype': 'fits', 'num': 10}, 'mos/target/2.0.0/fits/mos_sdss_id_flat-010.fits'),
+                              ('mos_target_sdss_id_flat', '@mos_target_num3',
+                               {'v_targ': '2.0.0', 'ftype': 'fits', 'num': '*'}, 'mos/target/2.0.0/fits/mos_sdss_id_flat-*.fits')],
                              ids=['configgrp', 'apgprefix-apo', 'apgprefix-lco', 'apgprefix-ins',
                                   'isplate-v6_0_4','pad_fieldid-5','pad_fieldid-6', 'frame-pad',
                                   'frame-nopadp', 'pad_fieldid-*','spcoaddfolder', 'sptypefolder',
-                                  'fieldgrp','spcoaddobs','epochflag','spcoaddgrp','lvm-tileid'])
+                                  'fieldgrp','spcoaddobs','epochflag','spcoaddgrp','lvm-tileid',
+                                  'mos_target_num3', 'mos_target_num3-star'])
     def test_special_function(self, path, name, special, keys, exp):
         assert special in path.templates[name]
         full = os.path.normpath(path.full(name, **keys))


### PR DESCRIPTION
This allows to do something like

```python
path.full("mos_target_sdss_id_flat", ftype="fits", v_targ="2.0.0", num="*")
```